### PR TITLE
Mixed-Content fix for MDI icons when using TileBoard over HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,6 +145,6 @@
 
 
 <link rel="stylesheet" async
-      href="http://cdn.materialdesignicons.com/2.4.85/css/materialdesignicons.min.css">
+      href="//cdn.materialdesignicons.com/2.4.85/css/materialdesignicons.min.css">
 </body>
 </html>


### PR DESCRIPTION
Fixes a mixed-content warning when loading the MDI icons if you're running TileBoard over HTTPS