### PR TITLE
Fix sensor tile to show default unit_of_measurement

### DIFF
--- a/tile.html
+++ b/tile.html
@@ -51,7 +51,7 @@
       <div class="item-entity">
          <span ng-bind="entityValue(item, entity)"
                class="item-entity--value"></span>
-         <span ng-if="item.unit" class="item-entity--unit"
+         <span ng-if="item.unit || entity.attributes.unit_of_measurement" class="item-entity--unit"
                ng-bind="item.unit || entity.attributes.unit_of_measurement"></span>
       </div>
    </div>
@@ -62,33 +62,6 @@
       <div class="item-entity">
          <span class="item-entity--icon mdi"
                ng-class="entityIcon(item, entity)"></span>
-      </div>
-   </div>
-
-   <div ng-if="item.type === TYPES.LOCK"
-        class="item-entity-container">
-
-      <div class="item-entity">
-         <span class="item-entity--icon mdi"
-               ng-class="entityIcon(item, entity)"></span>
-      </div>
-   </div>
-
-   <div ng-if="item.type === TYPES.COVER"
-        class="item-entity-container">
-      <div class="item-cover">
-         <div class="item-cover--button -open"
-              ng-click="sendCover('open_cover', item, entity)">
-            <i class="mdi mdi-arrow-up"></i>
-         </div>
-         <div class="item-cover--button -stop"
-              ng-click="sendCover('stop_cover', item, entity)">
-            <i class="mdi mdi-stop"></i>
-         </div>
-         <div class="item-cover--button -close"
-              ng-click="sendCover('close_cover', item, entity)">
-            <i class="mdi mdi-arrow-down"></i>
-         </div>
       </div>
    </div>
 


### PR DESCRIPTION
The sensor tile would only show a unit if `unit:` was defined in the JS configuration. This fix allows it to show the default unit_of_measurement from HomeAssistant if a `unit:` is not defined in JS.