### PR TITLE
Fix for sensor tile unit_of_measurement

### DIFF
--- a/tile.html
+++ b/tile.html
@@ -51,7 +51,7 @@
       <div class="item-entity">
          <span ng-bind="entityValue(item, entity)"
                class="item-entity--value"></span>
-         <span ng-if="item.unit" class="item-entity--unit"
+         <span ng-if="item.unit || entity.attributes.unit_of_measurement" class="item-entity--unit"
                ng-bind="item.unit || entity.attributes.unit_of_measurement"></span>
       </div>
    </div>


### PR DESCRIPTION
The sensor tile would only show a unit if `unit:` was defined in the JS configuration. This fix allows it to show the default unit_of_measurement from HomeAssistant if a `unit:` is not defined in JS.