### PR TITLE
Replacing 'includes' with 'indexOf' to support Internet Explorer 11 and other older browsers

### DIFF
--- a/scripts/main-controller.js
+++ b/scripts/main-controller.js
@@ -679,7 +679,8 @@ function MainController ($scope) {
       var domain = "homeassistant";
       var group = item.id.split('.')[0];
 
-      if(['switch', 'light', 'fan'].includes(group)) domain = group;
+      //if(['switch', 'light', 'fan'].includes(group)) domain = group;
+      if(['switch', 'light', 'fan'].indexOf(group)>=0) domain = group;
 
       var service = "toggle";
 

--- a/scripts/main-controller.js
+++ b/scripts/main-controller.js
@@ -679,7 +679,6 @@ function MainController ($scope) {
       var domain = "homeassistant";
       var group = item.id.split('.')[0];
 
-      //if(['switch', 'light', 'fan'].includes(group)) domain = group;
       if(['switch', 'light', 'fan'].indexOf(group)>=0) domain = group;
 
       var service = "toggle";


### PR DESCRIPTION
Replacing 'includes' with 'indexOf' to support Internet Explorer 11 and other older browsers. Other browsers still work. Work-around documentation: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes#Browser_compatibility