### PR TITLE
Add custom HTML to screensaver & hideOverlay capability

### DIFF
--- a/index.html
+++ b/index.html
@@ -250,10 +250,12 @@
    <div class="screensaver-slides" ng-if="isShowed">
       <div class="screensaver-slide" ng-style="getSlideStyle(slide)"
            ng-class="getSlideClasses($index, slide)"
-           ng-repeat="slide in slides track by $index"></div>
+           ng-repeat="slide in slides track by $index">
+           <div class="screensaver-html" ng-if="slide.html" ng-bind-html="slide.html"></div>
+      </div>
    </div>
 
-   <div class="screensaver-content" ng-if="isShowed">
+   <div class="screensaver-content" ng-if="isShowed && !hideOverlay">
       <div class="screensaver-datetime">
          <div class="screensaver-time">
             <clock></clock>

--- a/scripts/controllers/screensaver.js
+++ b/scripts/controllers/screensaver.js
@@ -14,6 +14,7 @@ function ScreensaverController ($scope) {
 
    $scope.now = new Date();
    $scope.isShowed = false;
+   $scope.hideOverlay = false;
    $scope.slides = conf.slides;
 
    $scope.getSlideClasses = function (index, slide) {
@@ -69,7 +70,8 @@ function ScreensaverController ($scope) {
       if(activeSlide >= $scope.slides.length) {
          activeSlide = 0;
       }
-
+	  
+      $scope.hideOverlay = $scope.slides[activeSlide].hideOverlay;
       if($scope.isShowed) {
          $scope.now = new Date();
 
@@ -81,6 +83,7 @@ function ScreensaverController ($scope) {
       setTimeout(function () {
          lastActivity = 0;
          $scope.isShowed = true;
+         $scope.hideOverlay = $scope.slides[activeSlide].hideOverlay;
          if(!$scope.$$phase) $scope.$digest();
       }, 100);
    };


### PR DESCRIPTION
Allows specifying custom HTML to be included on a screensaver slide, as well as hiding the clock overlay.

hideOverlay default to false if not specified.

```
slides: [
	{
		bg: 'images/bg3.jpg',
		html: '<div class="test">This is a test</div>',
		hideOverlay: true
	},
	{
		bg: 'images/slide2.jpg'
	}
]
```