### PR TITLE
Add iOS full-screen mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,9 @@
    <title>TileBoard</title>
 
    <meta name="mobile-web-app-capable" content="yes">
+   <!-- iOS Settings -->
+   <meta name="apple-mobile-web-app-capable" content="yes">
+   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 
    <link rel="stylesheet" href="styles/main.css"/>
    <link rel="stylesheet" href="styles/themes.css"/>


### PR DESCRIPTION
On iOS the tileboard can now be added to the frontscreen at full-screen mode.
Code is from https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html.