### PR TITLE
Fix/page menu obstruction

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -255,6 +255,9 @@ body {
   margin-top: 0.1em;
   font-size: 1em;
 }
+.-menu-bottom .page {
+  padding-bottom: 105px;
+}
 .-menu-bottom .page-head {
   left: 10px;
   right: 10px;

--- a/styles/main.less
+++ b/styles/main.less
@@ -1,3 +1,4 @@
+@pageMenuBottomOffset: 25px;
 @pageMenuWidth: 120px;
 @pageMenuIconFont: 32px;
 @pageMenuIconSize: 70px;
@@ -327,7 +328,7 @@ body {
 
    &.-bottom {
       left: 0;
-      bottom: 25px;
+      bottom: @pageMenuBottomOffset;
       right: 0;
 
       .pages-menu--item {

--- a/styles/main.less
+++ b/styles/main.less
@@ -2,7 +2,10 @@
 @pageMenuWidth: 120px;
 @pageMenuIconFont: 32px;
 @pageMenuIconSize: 70px;
+@pageMenuIconVerticalMargin: 5px;
 @groupMargin: 35px 50px 35px 15px;
+@pageBottomPadding: @pageMenuBottomOffset + @pageMenuIconSize
+      + 2 * @pageMenuIconVerticalMargin;
 
 @tileSize: 155px;
 @entitySize: 80px;
@@ -280,6 +283,10 @@ body {
 }
 
 .-menu-bottom {
+   .page {
+      padding-bottom: @pageBottomPadding;
+   }
+
    .page-head {
       left: 10px;
       right: 10px;
@@ -363,7 +370,7 @@ body {
       line-height: @pageMenuIconSize;
       text-align: center;
       opacity: 0.5;
-      margin: 5px auto;
+      margin: @pageMenuIconVerticalMargin auto;
       vertical-align: middle;
       cursor: pointer;
 

--- a/styles/themes.css
+++ b/styles/themes.css
@@ -147,6 +147,18 @@
 .-theme-compact.-menu-left.-groups-align-vertically .page {
   padding-left: 70px;
 }
+.-theme-winphone.-menu-bottom .page,
+.-theme-mobile.-menu-bottom .page,
+.-theme-compact.-menu-bottom .page {
+  padding-bottom: 50px;
+}
+@media (min-width: 500px) {
+  .-theme-winphone.-menu-bottom .page,
+  .-theme-mobile.-menu-bottom .page,
+  .-theme-compact.-menu-bottom .page {
+    padding-bottom: 62px;
+  }
+}
 .-theme-mobile .group-title,
 .-theme-winphone .group-title {
   height: 40px;
@@ -202,25 +214,13 @@
   border-radius: 100%;
   border: 3px solid rgba(255, 255, 255, 0.2);
 }
-.-theme-winphone {
-  font-size: 13.5px;
+.-theme-winphone.-menu-bottom .page {
+  padding-bottom: 56px;
 }
-.-theme-winphone .item {
-  color: #f5efee;
-  background: rgba(34, 102, 168, 0.3) !important;
-}
-.-theme-winphone .item:active {
-  background: rgba(34, 102, 168, 0.4) !important;
-}
-.-theme-winphone .item-state {
-  background: rgba(0, 0, 0, 0.15);
-}
-.-theme-winphone .pages-menu.-bottom {
-  background: #282828;
-}
-.-theme-winphone .pages-menu.-bottom .pages-menu--item {
-  border-radius: 100%;
-  border: 3px solid rgba(255, 255, 255, 0.2);
+@media (min-width: 500px) {
+  .-theme-winphone.-menu-bottom .page {
+    padding-bottom: 68px;
+  }
 }
 .-theme-homekit {
   color: #fff;
@@ -305,6 +305,7 @@
 .-theme-homekit .pages-menu.-bottom {
   background: #fafafa;
   border-top: 1px solid #d2d2d2;
+  bottom: 0;
 }
 .-theme-homekit .pages-menu.-bottom .pages-menu--item {
   color: #777;
@@ -341,6 +342,9 @@
 }
 .-theme-homekit input[type=range]::-moz-range-thumb {
   border-radius: 10px;
+}
+.-theme-homekit.-menu-bottom .page {
+  padding-bottom: 81px;
 }
 .-theme-homekit.-theme-mobile .item-state {
   padding: 4px 5px 2px !important;

--- a/styles/themes.less
+++ b/styles/themes.less
@@ -223,34 +223,6 @@
    }
 }
 
-.-theme-winphone {
-   font-size: 13.5px;
-
-   .item {
-      color: rgb(245, 239, 238);
-      background: rgba(34, 102, 168, 0.3) !important;
-
-      &:active {
-         background: rgba(34, 102, 168, 0.4) !important;
-      }
-
-      &-state {
-         background: rgba(0, 0, 0, 0.15);
-      }
-   }
-
-   .pages-menu.-bottom {
-      background: rgb(40, 40, 40);
-
-      .pages-menu {
-         &--item {
-            border-radius: 100%;
-            border: 3px solid rgba(255,255,255,.2);
-         }
-      }
-   }
-}
-
 
 .-theme-homekit {
    color: #fff;

--- a/styles/themes.less
+++ b/styles/themes.less
@@ -1,3 +1,15 @@
+// Following variables are used by winphone, mobile and compact themes only even
+// thought that is not specified in the names to avoid long variable names.
+@pageMenuBottomPadding: 3px;
+@pageMenuIconSizeSmall: 38px;
+@pageMenuIconSizeBig: 46px;
+@pageMenuIconVerticalMarginSmall: 3px;
+@pageMenuIconVerticalMarginBig: 5px;
+
+@pageBottomPaddingSmall: 2 * @pageMenuBottomPadding + @pageMenuIconSizeSmall
+      + 2 * @pageMenuIconVerticalMarginSmall;
+@pageBottomPaddingBig: 2 * @pageMenuBottomPadding + @pageMenuIconSizeBig
+      + 2 * @pageMenuIconVerticalMarginBig;
 
 
 .-theme-transparent {
@@ -104,7 +116,7 @@
       }
 
       &.-bottom {
-         padding: 3px;
+         padding: @pageMenuBottomPadding;
          background: rgba(32, 35, 37, 0.4);
          bottom: 0;
       }
@@ -113,9 +125,9 @@
          &--item {
             font-size: 24px;
             line-height: 36px;
-            width: 38px;
-            height: 38px;
-            margin: 3px 5px;
+            width: @pageMenuIconSizeSmall;
+            height: @pageMenuIconSizeSmall;
+            margin: @pageMenuIconVerticalMarginSmall 5px;
             opacity: 0.6;
 
             &.-active {
@@ -132,9 +144,9 @@
             &--item {
                font-size: 30px;
                line-height: 44px;
-               width: 46px;
-               height: 46px;
-               margin: 5px 5px;
+               width: @pageMenuIconSizeBig;
+               height: @pageMenuIconSizeBig;
+               margin: @pageMenuIconVerticalMarginBig 5px;
             }
          }
       }
@@ -148,6 +160,18 @@
       &.-groups-align-vertically {
          .page {
             padding-left: 70px;
+         }
+      }
+   }
+
+   &.-menu-bottom {
+      .page {
+         padding-bottom: @pageBottomPaddingSmall;
+      }
+
+      @media (min-width: 500px) {
+         .page {
+            padding-bottom: @pageBottomPaddingBig;
          }
       }
    }
@@ -196,6 +220,8 @@
 
 
 .-theme-winphone {
+   @winphonePageMenuIconBorderSize: 3px;
+
    font-size: 13.5px;
 
    .item {
@@ -217,7 +243,19 @@
       .pages-menu {
          &--item {
             border-radius: 100%;
-            border: 3px solid rgba(255,255,255,.2);
+            border: @winphonePageMenuIconBorderSize solid rgba(255,255,255,.2);
+         }
+      }
+   }
+
+   &.-menu-bottom {
+      .page {
+         padding-bottom: @pageBottomPaddingSmall + 2 * @winphonePageMenuIconBorderSize;
+      }
+
+      @media (min-width: 500px) {
+         .page {
+            padding-bottom: @pageBottomPaddingBig + 2 * @winphonePageMenuIconBorderSize;
          }
       }
    }
@@ -226,6 +264,11 @@
 
 .-theme-homekit {
    @pageMenuBottomOffset: 0;
+   @pageMenuBottomTopBorderWidth: 1px;
+   @pageMenuIconSize: 70px;
+   @pageMenuIconVerticalMargin: 5px;
+   @pageBottomPadding: @pageMenuBottomOffset + @pageMenuBottomTopBorderWidth
+         + @pageMenuIconSize + 2 * @pageMenuIconVerticalMargin;;
 
    color: #fff;
    background: #eee !important;
@@ -323,7 +366,7 @@
 
    .pages-menu.-bottom {
       background: #fafafa;
-      border-top: 1px solid #d2d2d2;
+      border-top: @pageMenuBottomTopBorderWidth solid #d2d2d2;
       bottom: @pageMenuBottomOffset;
 
       .pages-menu {
@@ -374,6 +417,11 @@
       border-radius: 10px;
    }
 
+   &.-menu-bottom {
+      .page {
+         padding-bottom: @pageBottomPadding;
+      }
+   }
 
    &.-theme-mobile {
       .item {

--- a/styles/themes.less
+++ b/styles/themes.less
@@ -225,6 +225,8 @@
 
 
 .-theme-homekit {
+   @pageMenuBottomOffset: 0;
+
    color: #fff;
    background: #eee !important;
 
@@ -322,6 +324,7 @@
    .pages-menu.-bottom {
       background: #fafafa;
       border-top: 1px solid #d2d2d2;
+      bottom: @pageMenuBottomOffset;
 
       .pages-menu {
          &--item {


### PR DESCRIPTION
    Fix partially obstructed tiles by bottom-positioned page menu (#100)

    When there is enough content to enable vertical scrolling and page menu toolbar
    is at the bottom, the tiles that were at the bottom might have been obstructed
    by the toolbar, making it impossible to click some parts of them.

    Fixed by adding bottom padding to page area equal to size of the toolbar
    (+ toolbar's bottom offset when not 0). This ensures that tiles can be
    scrolled fully in view without being obstructed.