### PR TITLE
Use padding in bottom-positioned pages-menu instead of bottom offset

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -256,7 +256,7 @@ body {
   font-size: 1em;
 }
 .-menu-bottom .page {
-  padding-bottom: 105px;
+  padding-bottom: 104px;
 }
 .-menu-bottom .page-head {
   left: 10px;
@@ -296,8 +296,9 @@ body {
 }
 .pages-menu.-bottom {
   left: 0;
-  bottom: 25px;
+  bottom: 0;
   right: 0;
+  padding: 12px 0;
 }
 .pages-menu.-bottom .pages-menu--item {
   display: inline-block;

--- a/styles/main.less
+++ b/styles/main.less
@@ -1,10 +1,10 @@
-@pageMenuBottomOffset: 25px;
+@pageMenuVerticalPadding: 12px;
 @pageMenuWidth: 120px;
 @pageMenuIconFont: 32px;
 @pageMenuIconSize: 70px;
 @pageMenuIconVerticalMargin: 5px;
 @groupMargin: 35px 50px 35px 15px;
-@pageBottomPadding: @pageMenuBottomOffset + @pageMenuIconSize
+@pageBottomPadding: 2 * @pageMenuVerticalPadding + @pageMenuIconSize
       + 2 * @pageMenuIconVerticalMargin;
 
 @tileSize: 155px;
@@ -335,8 +335,9 @@ body {
 
    &.-bottom {
       left: 0;
-      bottom: @pageMenuBottomOffset;
+      bottom: 0;
       right: 0;
+      padding: @pageMenuVerticalPadding 0;
 
       .pages-menu--item {
          display: inline-block;

--- a/styles/themes.css
+++ b/styles/themes.css
@@ -305,7 +305,7 @@
 .-theme-homekit .pages-menu.-bottom {
   background: #fafafa;
   border-top: 1px solid #d2d2d2;
-  bottom: 0;
+  padding: 0;
 }
 .-theme-homekit .pages-menu.-bottom .pages-menu--item {
   color: #777;

--- a/styles/themes.less
+++ b/styles/themes.less
@@ -263,11 +263,10 @@
 
 
 .-theme-homekit {
-   @pageMenuBottomOffset: 0;
    @pageMenuBottomTopBorderWidth: 1px;
    @pageMenuIconSize: 70px;
    @pageMenuIconVerticalMargin: 5px;
-   @pageBottomPadding: @pageMenuBottomOffset + @pageMenuBottomTopBorderWidth
+   @pageBottomPadding: @pageMenuBottomTopBorderWidth
          + @pageMenuIconSize + 2 * @pageMenuIconVerticalMargin;;
 
    color: #fff;
@@ -367,7 +366,7 @@
    .pages-menu.-bottom {
       background: #fafafa;
       border-top: @pageMenuBottomTopBorderWidth solid #d2d2d2;
-      bottom: @pageMenuBottomOffset;
+      padding: 0;
 
       .pages-menu {
          &--item {


### PR DESCRIPTION
The only reason for this change is to prepare code for future fix.
It should be almost equally visually to previous code.

Previous code applied bottom offset to bottom-positioned page menu which
created a gap that would let clicks go through it if page was scrolled.
Using padding instead makes sure there is no gap there and also allows
to created better scrolling indicator in the future.