### PR TITLE
Fix header weather widget image style

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -232,6 +232,9 @@ body {
 }
 .header-weather--icon > div,
 .header-weather--icon-image > div {
+  background-size: contain;
+  background-position: center;
+  background-repeat: no-repeat;
   width: 2em;
   height: 2em;
   margin: -0.2em 0;
@@ -240,11 +243,6 @@ body {
   vertical-align: middle;
   display: inline-block;
   text-align: center;
-}
-.header-weather--icon--image div {
-  background-size: contain;
-  background-position: center;
-  background-repeat: no-repeat;
 }
 .header-weather--temperature {
   display: inline-block;

--- a/styles/main.less
+++ b/styles/main.less
@@ -247,6 +247,9 @@ body {
       &--icon {
          &, &-image {
             > div {
+               background-size: contain;
+               background-position: center;
+               background-repeat: no-repeat;
                width: 2em;
                height: 2em;
                margin: -0.2em 0;
@@ -257,14 +260,6 @@ body {
             vertical-align: middle;
             display: inline-block;
             text-align: center;
-         }
-
-         &--image {
-            div {
-               background-size: contain;
-               background-position: center;
-               background-repeat: no-repeat;
-            }
          }
       }
 


### PR DESCRIPTION
Image was repeating and wasn't centered as there are no elements with
class .header-weather--icon--image, only .header-weather--icon-image
(--image vs. -image). Move css rules to the correct selector.