### PR TITLE
Darken transparent page menu background when page is scrolled (#104)

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,6 +216,8 @@
    <div class="pages-menu" ng-if="showPagesMenu()"
         ng-class="pagesMenuClasses()">
 
+      <div class="pages-menu--scroll-indicator"></div>
+
       <div class="pages-menu--aligner"></div>
 
       <div class="pages-menu--items">
@@ -238,7 +240,8 @@
       <div ng-repeat="page in pages track by $index"
            ng-class="{'-active': isPageActive(page)}"
            ng-if="shouldDrawPage(page) && !isHidden(page)"
-           ng-style="pageStyles(page)" class="page">
+           ng-style="pageStyles(page)" class="page"
+           on-scroll on-scroll-model="page">
 
          <-- legacy -->
          <div class="page-head" ng-if="page.head && headWarning()"

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -102,7 +102,19 @@ function MainController ($scope) {
          }
       }
 
-      return bodyClass;
+      var scrollClasses = [];
+
+      if(activePage) {
+         if(activePage.scrolledHorizontally) {
+            scrollClasses.push('-scrolled-horizontally');
+         }
+
+         if(activePage.scrolledVertically) {
+            scrollClasses.push('-scrolled-vertically');
+         }
+      }
+
+      return bodyClass.concat(scrollClasses);
    };
 
 
@@ -1568,6 +1580,11 @@ function MainController ($scope) {
    angular.element(window).on('view:updated', function () {
       updateView();
    });
+
+   $scope.$watchGroup([
+     'activePage.scrolledVertically',
+     'activePage.scrolledHorizontally',
+   ], updateView);
 
    function calcGroupSizes (group) {
       var maxWidth = 0;

--- a/scripts/directives.js
+++ b/scripts/directives.js
@@ -303,18 +303,32 @@ App.directive('onScroll', [function () {
          onScrollModel: '=',
       },
       link: function ($scope, $el, attrs) {
+         var lastScrolledHorizontally = false;
+         var lastScrolledVertically = false;
+
          var determineScroll = function () {
-            $scope.onScrollModel.scrolledHorizontally =
-               $el[0].scrollLeft !== 0;
-            $scope.onScrollModel.scrolledVertically =
-               $el[0].scrollTop !== 0;
+            var scrolledHorizontally = $el[0].scrollLeft !== 0;
+            var scrolledVertically = $el[0].scrollTop !== 0;
+
+            if(lastScrolledVertically !== scrolledVertically ||
+               lastScrolledHorizontally !== scrolledHorizontally) {
+               $scope.onScrollModel.scrolledHorizontally =
+                  lastScrolledHorizontally = scrolledHorizontally;
+               $scope.onScrollModel.scrolledVertically =
+                  lastScrolledVertically = scrolledVertically;
+
+               return true;
+            }
+
+            return false;
          };
 
          determineScroll();
 
          $el.on('scroll', function () {
-            determineScroll();
-            $scope.$apply();
+            if(determineScroll()) {
+               $scope.$apply();
+            }
          });
       },
    }

--- a/scripts/directives.js
+++ b/scripts/directives.js
@@ -295,3 +295,28 @@ App.directive('date', ['$interval', function ($interval) {
    }
 }]);
 
+
+App.directive('onScroll', [function () {
+   return {
+      restrict: 'A',
+      scope: {
+         onScrollModel: '=',
+      },
+      link: function ($scope, $el, attrs) {
+         var determineScroll = function () {
+            $scope.onScrollModel.scrolledHorizontally =
+               $el[0].scrollLeft !== 0;
+            $scope.onScrollModel.scrolledVertically =
+               $el[0].scrollTop !== 0;
+         };
+
+         determineScroll();
+
+         $el.on('scroll', function () {
+            determineScroll();
+            $scope.$apply();
+         });
+      },
+   }
+}]);
+

--- a/styles/main.css
+++ b/styles/main.css
@@ -301,7 +301,7 @@ body {
   top: 0;
 }
 .pages-menu.-left .pages-menu--scroll-indicator {
-  background-image: linear-gradient(to right, rgba(0, 0, 0, 0.1) 98%, rgba(0, 0, 0, 0.3) 98%, rgba(0, 0, 0, 0));
+  box-shadow: 1px 0 5px rgba(0, 0, 0, 0.5);
 }
 .pages-menu.-bottom {
   left: 0;
@@ -310,7 +310,7 @@ body {
   padding: 12px 0;
 }
 .pages-menu.-bottom .pages-menu--scroll-indicator {
-  background-image: linear-gradient(to top, rgba(0, 0, 0, 0.1) 98%, rgba(0, 0, 0, 0.3) 98%, rgba(0, 0, 0, 0));
+  box-shadow: 0 1px 5px rgba(0, 0, 0, 0.5);
 }
 .pages-menu.-bottom .pages-menu--item {
   display: inline-block;
@@ -319,6 +319,7 @@ body {
   margin-top: 0 !important;
 }
 .pages-menu--scroll-indicator {
+  background-color: rgba(0, 0, 0, 0.1);
   height: 100%;
   left: 0;
   opacity: 0;

--- a/styles/main.css
+++ b/styles/main.css
@@ -255,6 +255,12 @@ body {
   margin-top: 0.1em;
   font-size: 1em;
 }
+.-menu-left.-scrolled-horizontally .pages-menu--scroll-indicator {
+  opacity: 1;
+}
+.-menu-bottom.-scrolled-vertically .pages-menu--scroll-indicator {
+  opacity: 1;
+}
 .-menu-bottom .page {
   padding-bottom: 104px;
 }
@@ -294,17 +300,32 @@ body {
   bottom: 0;
   top: 0;
 }
+.pages-menu.-left .pages-menu--scroll-indicator {
+  background-image: linear-gradient(to right, rgba(0, 0, 0, 0.1) 98%, rgba(0, 0, 0, 0.3) 98%, rgba(0, 0, 0, 0));
+}
 .pages-menu.-bottom {
   left: 0;
   bottom: 0;
   right: 0;
   padding: 12px 0;
 }
+.pages-menu.-bottom .pages-menu--scroll-indicator {
+  background-image: linear-gradient(to top, rgba(0, 0, 0, 0.1) 98%, rgba(0, 0, 0, 0.3) 98%, rgba(0, 0, 0, 0));
+}
 .pages-menu.-bottom .pages-menu--item {
   display: inline-block;
 }
 .pages-menu.-bottom .pages-menu--items {
   margin-top: 0 !important;
+}
+.pages-menu--scroll-indicator {
+  height: 100%;
+  left: 0;
+  opacity: 0;
+  position: absolute;
+  top: 0;
+  transition: opacity 0.3s;
+  width: 100%;
 }
 .pages-menu--items {
   display: inline-block;

--- a/styles/main.less
+++ b/styles/main.less
@@ -347,9 +347,7 @@ body {
       top: 0;
 
       .pages-menu--scroll-indicator {
-         background-image: linear-gradient(
-            to right,
-            rgba(0, 0, 0, .1) 98%, rgba(0, 0, 0, .3) 98%, rgba(0, 0, 0, 0));
+         box-shadow: 1px 0 5px rgba(0, 0, 0, .5);
       }
    }
 
@@ -360,9 +358,7 @@ body {
       padding: @pageMenuVerticalPadding 0;
 
       .pages-menu--scroll-indicator {
-         background-image: linear-gradient(
-            to top,
-            rgba(0, 0, 0, .1) 98%, rgba(0, 0, 0, .3) 98%, rgba(0, 0, 0, 0));
+         box-shadow: 0 1px 5px rgba(0, 0, 0, .5);
       }
 
       .pages-menu--item {
@@ -375,6 +371,7 @@ body {
    }
 
    &--scroll-indicator {
+      background-color: rgba(0, 0, 0, .1);
       height: 100%;
       left: 0;
       opacity: 0;

--- a/styles/main.less
+++ b/styles/main.less
@@ -282,7 +282,21 @@ body {
    }
 }
 
+.-menu-left {
+   &.-scrolled-horizontally {
+      .pages-menu--scroll-indicator {
+         opacity: 1;
+      }
+   }
+}
+
 .-menu-bottom {
+   &.-scrolled-vertically {
+      .pages-menu--scroll-indicator {
+         opacity: 1;
+      }
+   }
+
    .page {
       padding-bottom: @pageBottomPadding;
    }
@@ -331,6 +345,12 @@ body {
       left: 0;
       bottom: 0;
       top: 0;
+
+      .pages-menu--scroll-indicator {
+         background-image: linear-gradient(
+            to right,
+            rgba(0, 0, 0, .1) 98%, rgba(0, 0, 0, .3) 98%, rgba(0, 0, 0, 0));
+      }
    }
 
    &.-bottom {
@@ -339,6 +359,12 @@ body {
       right: 0;
       padding: @pageMenuVerticalPadding 0;
 
+      .pages-menu--scroll-indicator {
+         background-image: linear-gradient(
+            to top,
+            rgba(0, 0, 0, .1) 98%, rgba(0, 0, 0, .3) 98%, rgba(0, 0, 0, 0));
+      }
+
       .pages-menu--item {
          display: inline-block;
       }
@@ -346,6 +372,16 @@ body {
       .pages-menu--items {
          margin-top: 0 !important;
       }
+   }
+
+   &--scroll-indicator {
+      height: 100%;
+      left: 0;
+      opacity: 0;
+      position: absolute;
+      top: 0;
+      transition: opacity .3s;
+      width: 100%;
    }
 
    &--items {

--- a/styles/themes.css
+++ b/styles/themes.css
@@ -105,6 +105,11 @@
   background: rgba(32, 35, 37, 0.4);
   bottom: 0;
 }
+.-theme-winphone .pages-menu.-bottom .pages-menu--scroll-indicator,
+.-theme-mobile .pages-menu.-bottom .pages-menu--scroll-indicator,
+.-theme-compact .pages-menu.-bottom .pages-menu--scroll-indicator {
+  display: none;
+}
 .-theme-winphone .pages-menu .pages-menu--item,
 .-theme-mobile .pages-menu .pages-menu--item,
 .-theme-compact .pages-menu .pages-menu--item {
@@ -306,6 +311,9 @@
   background: #fafafa;
   border-top: 1px solid #d2d2d2;
   padding: 0;
+}
+.-theme-homekit .pages-menu.-bottom .pages-menu--scroll-indicator {
+  display: none;
 }
 .-theme-homekit .pages-menu.-bottom .pages-menu--item {
   color: #777;

--- a/styles/themes.less
+++ b/styles/themes.less
@@ -119,6 +119,10 @@
          padding: @pageMenuBottomPadding;
          background: rgba(32, 35, 37, 0.4);
          bottom: 0;
+
+         .pages-menu--scroll-indicator {
+            display: none;
+         }
       }
 
       .pages-menu {
@@ -367,6 +371,10 @@
       background: #fafafa;
       border-top: @pageMenuBottomTopBorderWidth solid #d2d2d2;
       padding: 0;
+
+      .pages-menu--scroll-indicator {
+         display: none;
+      }
 
       .pages-menu {
          &--item {


### PR DESCRIPTION
To clearly indicate that the area under page menu is not clickable when
there are tiles underneath, darken its barkgroung when page is scrolled either
vertically (with page menu on the bottom) or horizontally (page menu on the left).