### PR TITLE
Disable debug console logs by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ var CONFIG = {
     */
    password: null,
 
+   /* debug: Toggle for extra debugging information.
+    * If enabled, will print info about state changes and entities to console.
+    */
+   debug: Boolean,
+
    /* timeFormat: 12 for AM/PM marker, 24 for 24 hour time (default) */
    timeFormat: Number,
    

--- a/config.example.js
+++ b/config.example.js
@@ -18,6 +18,7 @@ var CONFIG = {
    passwordType: PASSWORD_TYPES.PROMPT_AND_SAVE,
    //password: null,
    //googleApiKey: "XXXXXXXXXX", // Required if you are using Google Maps for device tracker
+   debug: false, // Prints entities and state change info to the console.
 
    // next fields are optional
    events: [],

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -1539,16 +1539,16 @@ function MainController ($scope) {
 
    Api.onReady(function () {
       Api.subscribeEvents("state_changed", function (res) {
-         console.log('subscribed to state_changed', res);
+         debugLog('subscribed to state_changed', res);
       });
 
       Api.subscribeEvents("tileboard", function (res) {
-         console.log('subscribed to tileboard', res);
+         debugLog('subscribed to tileboard', res);
       });
 
       Api.getStates(function (res) {
          if(res.success) {
-            console.log(res.result);
+            debugLog(res.result);
 
             // in case of development, when sensors are predefined
             if(window.DEBUG_SENSORS) {
@@ -1742,13 +1742,13 @@ function MainController ($scope) {
    function handleEvent (event) {
       try {
          if (event.event_type === "state_changed") {
-            console.log('state change', event.data.entity_id, event.data.new_state);
+            debugLog('state change', event.data.entity_id, event.data.new_state);
 
             setNewState(event.data.entity_id, event.data.new_state);
             checkStatesTriggers(event.data.entity_id, event.data.new_state);
          }
          else if (event.event_type === "tileboard") {
-            console.log('tileboard', event.data);
+            debugLog('tileboard', event.data);
 
             triggerEvents(event.data);
          }
@@ -1764,6 +1764,12 @@ function MainController ($scope) {
          message: error,
          lifetime: 10
       });
+   }
+
+   function debugLog () {
+      if(CONFIG.debug) {
+         console.log.apply(console, [].slice.call(arguments));
+      }
    }
 
    function updateView () {


### PR DESCRIPTION
Just wanted to clean up console which helps especially when developing.
I own a motion sensor that sends state changes for 6 different entities every
few seconds. That makes it easy to miss errors in the console.