### PR TITLE
Fix remaining problem of #114 with hash being rewritten to path on re…

### DIFF
--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -1,6 +1,6 @@
-App.controller('Main', ['$scope', MainController]);
+App.controller('Main', ['$scope', '$location', MainController]);
 
-function MainController ($scope) {
+function MainController ($scope, $location) {
    if(!window.CONFIG) return;
 
    $scope.pages = CONFIG.pages;
@@ -1272,7 +1272,7 @@ function MainController ($scope) {
          }, 20);
       }
       if (CONFIG.rememberLastPage) {
-         location.hash = $scope.pages.indexOf(page) + '';
+         $location.hash($scope.pages.indexOf(page));
       }
    };
 
@@ -1575,7 +1575,7 @@ function MainController ($scope) {
 
          $scope.ready = true;
 
-         var pageNum = location.hash.slice(1);
+         var pageNum = $location.hash();
 
          if (!CONFIG.rememberLastPage || !$scope.pages[pageNum]) {
             pageNum = 0;

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -9,7 +9,6 @@ App.config(function($locationProvider) {
       enabled: true,
       requireBase: false
    });
-   $locationProvider.hashPrefix('');
 });
 
 


### PR DESCRIPTION
…load

As explained in https://github.com/angular/angular.js/issues/5529, with:
 - URL `path` being non-empty
 - and html5 mode enabled
 - and hashPrefix set to empty string

angularjs will rewrite hashbang to path on document reload. That is not
desired as then the server would return 404.