### PR TITLE
media_player volume buttons if statement alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -1004,7 +1004,7 @@
                   </td>
                </tr>
 
-               <tr ng-if="!supportsFeature(FEATURES.VOLUME_SET, entity) && supportsFeature(FEATURES.VOLUME_STEP, entity) && entity.state !== 'off'">
+               <tr ng-if="!(supportsFeature(FEATURES.VOLUME_SET, entity) && (_c = getVolumeConf(item, entity))) && supportsFeature(FEATURES.VOLUME_STEP, entity) && entity.state !== 'off'">
                   <td colspan="3" class="media-player-table--td-volume-buttons">
                      <div class="media-player--button -volume_down"
                           ng-click="sendPlayer('volume_down', item, entity)">


### PR DESCRIPTION
This fixes an issue I have with a silicon frontier internet radio (and probably others). This player supports both VOLUME_SET and VOLUME_STEP. However, the if statement for VOLUME_SET also checks the current level, which this items cannot provide. This means that no volume controls at all are shown. By adding this second condition also to the VOLUME_STEP block ensures that at leasst the plus/minus controls are available.