### PR TITLE
Fix for partially opened covers #164

### DIFF
--- a/index.html
+++ b/index.html
@@ -482,7 +482,7 @@
 
          <div class="item-cover">
             <div class="item-cover--button -open"
-                 ng-class="{'-disabled': entity.state === 'open'}"
+                 ng-class="{'-disabled': entity.state === 'open' && (!entity.attributes.current_position || entity.attributes.current_position === 100)}"
                  ng-click="sendCover('open_cover', item, entity)">
                <i class="mdi mdi-arrow-up"></i>
             </div>


### PR DESCRIPTION
By default the cover tile disables the `open` control in case the
entity state is already set to `open`. This might be OK for covers
without positioning details, but not for covers which report their
position back to HA.

Thus, this change will enhance the `open` control to support covers with
partial positions. It will change the behaviour of the `open` control
in the following way. With this change, the `open` control will only be
disabled when:

1. The state is `open` and there's no `current_position` attribute (legacy / backward compatibility)

2. The state is `open` and the `current_position` attribute equals `100` (new position support)