### PR TITLE
Disabling text selection

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -1,3 +1,11 @@
+html, body {
+	-moz-user-select: none; /* Firefox */
+  -ms-user-select: none; /* Internet Explorer */
+  -khtml-user-select: none; /* KHTML browsers (e.g. Konqueror) */
+  -webkit-user-select: none; /* Chrome, Safari, and Opera */
+  -webkit-touch-callout: none; /* Disable Android and iOS callouts*/
+}
+
 .item.-th-transparent {
   background-color: rgba(84, 92, 102, 0.6);
 }


### PR DESCRIPTION
This edit disables text selection on the page, eliminating situations where long presses accidentally select text. To my knowledge, this doesn't mess with any other touch functionality.