### PR TITLE
Use `field` mechanism for value in sliders

### DIFF
--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -709,12 +709,13 @@ function MainController ($scope, $location) {
 
       var def = item.slider || {};
       var attrs = entity.attributes || {};
-
+      var value = +attrs[def.field] || 0;
+      
       entity.attributes[key] = {
          max: attrs.max || def.max || 100,
          min: attrs.min || def.min || 0,
          step: attrs.step || def.step || 1,
-         value: +entity.state || def.value || 0,
+         value: value || +entity.state || def.value || 0,
          request: def.request || {
             type: "call_service",
             domain: "input_number",


### PR DESCRIPTION
Just like the LightSliderConf, allow the configuration to include a `field` and use that as the attribute name to be used for the value of the slider.

This is the same the is being done in `getLightSliderConf`, so seems suitable in that context, if I understood everything correctly. This was my approach to solve #209, but I may have overlooked "the proper way", maybe?