### PR TITLE
Ignore any *config files in site root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 /sensors.js
 /config.js
+/*config.js
 .idea/*
 .idea
 *.map


### PR DESCRIPTION
So you can have additional config files, like mobile-config.js, ipad.config.js, etc. at the site root and have them be ignored by git.