### PR TITLE
Fixed a couple of issues where urls from HA are not being prepended w…

### DIFF
--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -283,7 +283,7 @@ function MainController ($scope, $location) {
          var styles = {};
 
          if(entity.attributes.entity_picture) {
-            styles.backgroundImage = 'url(' + entity.attributes.entity_picture + ')';
+            styles.backgroundImage = 'url(' + CONFIG.serverUrl + entity.attributes.entity_picture + ')';
          }
 
          entity.trackerBg = styles;

--- a/scripts/directives.js
+++ b/scripts/directives.js
@@ -31,7 +31,7 @@ App.directive('camera', function () {
          var appendImage = function (url) {
             var el = document.createElement('div');
 
-            if(url) el.style.backgroundImage = 'url(' + url + ')';
+            if(url) el.style.backgroundImage = 'url(' + CONFIG.serverUrl + url + ')';
 
             el.style.backgroundSize = $scope.item.bgSize || 'cover';
 


### PR DESCRIPTION
…ith serverUrl

When running tileboard under HA these are not an issue since it picks
them up as relative URLs just fine. But when running tileboard somewhere
else the relative URLs that are defaulted to are wrong. Ex: if my
tileboard website is at http://mylocalsite.com/ then the default url for
my background image is http://mylocalsite.com/local/images/users/dan.jpg
when it should be http://hassio.local/local/images/users/dan.jpg

There could be more as I have not implemented every tile type. I found the entity background image issue pretty quickly. I just discovered the one for the camera recently. If I discover any more I will PR them as I find them.