### PR TITLE
Changed color picker to be config option rather than implicit

### DIFF
--- a/index.html
+++ b/index.html
@@ -682,7 +682,7 @@
                </div>
             </div>
           
-            <div ng-if="entity.attributes.rgb_color" class="item-entity-colorpicker">
+            <div ng-if="item.colorpicker" class="item-entity-colorpicker">
                <span>Color:</span> 
                <input color-picker 
                   color-picker-model="getRGBStringFromArray(entity.attributes.rgb_color)"

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -798,7 +798,7 @@ function MainController ($scope, $location) {
    };
 
    $scope.openLightSliders = function (item, entity) {
-      if(!item.sliders || !item.sliders.length) return;
+      if((!item.sliders || !item.sliders.length) && !item.colorpicker) return;
 
       if(entity.state !== "on") {
          return $scope.toggleSwitch(item, entity, function () {

--- a/styles/main.css
+++ b/styles/main.css
@@ -1339,7 +1339,7 @@ camera-thumbnail div {
 .item-entity-colorpicker {
   text-align: left;
   font-size: 0.9em;
-  margin: 3px;
+  margin: 10px 5px 0;
 }
 .item-entity-colorpicker input {
   width: 20px;

--- a/styles/main.less
+++ b/styles/main.less
@@ -1458,7 +1458,7 @@ camera-thumbnail {
 .item-entity-colorpicker {
    text-align: left;
    font-size: 0.9em;
-   margin: 3px;
+   margin: 10px 5px 0;
 
    input {
       width: 15px;


### PR DESCRIPTION
Changed color picker to be a config option for lights rather than
implicitly diplayed if entity has rgb_color attribute (though they will
not do anything in HA if entity does not have rgb_color attribute).
Fixed bug so that color picker can be used when sliders are not being
used. Fixed margins to better match sliders.

if light config has the following then color picker will be displayed on the longpress view:
```
colorpicker: true,
```
Perhaps future changes will have the colorpicker configuration to be more like sliders and allow you to specify which attribute to update, which type of color values to use (RBG, HEX, or HLSA), etc. I only have one color changing bulb to test with, others may be different. 
