### PR TITLE
Fully qualified entity_picture url

### DIFF
--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -308,9 +308,9 @@ function MainController ($scope, $location) {
 
          if(entity.attributes.entity_picture) {
             var url = entity.attributes.entity_picture;
-             if (url.indexOf('http') !== 0) {
-                 url = CONFIG.serverUrl + entity.attributes.entity_picture;
-             }
+            if (url.indexOf('http') !== 0) {
+               url = CONFIG.serverUrl + entity.attributes.entity_picture;
+            }
             styles.backgroundImage = 'url(' + url + ')';
          }
 

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -307,7 +307,11 @@ function MainController ($scope, $location) {
          var styles = {};
 
          if(entity.attributes.entity_picture) {
-            styles.backgroundImage = 'url(' + CONFIG.serverUrl + entity.attributes.entity_picture + ')';
+            var url = entity.attributes.entity_picture;
+             if (url.indexOf('http') !== 0) {
+                 url = CONFIG.serverUrl + entity.attributes.entity_picture;
+             }
+            styles.backgroundImage = 'url(' + url + ')';
          }
 
          entity.trackerBg = styles;


### PR DESCRIPTION
I use direct links for facebook profile pictures and entity picture and the tracks keeps appending the server url to it. Small fix working locally.