### PR TITLE
Fixed cover tile wrongly disable open function.

### DIFF
--- a/index.html
+++ b/index.html
@@ -482,7 +482,7 @@
 
          <div class="item-cover">
             <div class="item-cover--button -open"
-                 ng-class="{'-disabled': entity.state === 'open'}"
+                 ng-class="{'-disabled': entity.attributes.current_position === 100}"
                  ng-click="sendCover('open_cover', item, entity)">
                <i class="mdi mdi-arrow-up"></i>
             </div>


### PR DESCRIPTION
Covers report "open" as long as they are not fully closed. Only then the state changes to "closed". The cover tile would disable the open function until the cover was fully closed. If you have covers down at 50% you would need to get down to closed before you could open them again. 
This change looks at the "current_position" attribute and only disable the open function if the position is 100%, meaning fully open. 
If the cover does not support position then the open function will never be disabled. 
This is the same behaviour as Home assistant. 