### PR TITLE
Fix item and entity not being passed to getWeatherLine

### DIFF
--- a/index.html
+++ b/index.html
@@ -919,7 +919,7 @@
             </div>
 
             <div class="weather-line" ng-repeat="line in item.fields.list">
-               <span ng-bind="getWeatherLine(line, item. entity)"></span>
+               <span ng-bind="getWeatherLine(line, item, entity)"></span>
             </div>
 
             <!-- DEPRECATED -->


### PR DESCRIPTION
This was making writing anonymous methods for the line section of the weather module much more difficult.