### PR TITLE
fix: wrong initial month in INPUT_DATETIME picker

### DIFF
--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -1437,7 +1437,7 @@ function MainController ($scope, $location) {
          var d = new Date();
 
          $scope.datetimeString = d.getFullYear() + "";
-         $scope.datetimeString += leadZero(d.getMonth());
+         $scope.datetimeString += leadZero(d.getMonth() + 1);
          $scope.datetimeString += leadZero(d.getDate());
       }
    };


### PR DESCRIPTION
Since `getMonth()` returns 0-based month, we need to add 1 to get
current month.

Resolves #235