### PR TITLE
Add automated configuration functions and some examples

### DIFF
--- a/autoconfig.js
+++ b/autoconfig.js
@@ -7,11 +7,13 @@
  */
 function autoTile(id, position, args) {
    // Match the id against the templates (sorted to match most specific first)
-   var template = Object.keys(TEMPLATES.FILTERS).sort().reverse().find(
-      function(k) {
-         return id.match(k) !== null
-      }
-   );
+   var template;
+   if (typeof id != 'undefined')
+      template = Object.keys(TEMPLATES.FILTERS).sort().reverse().find(
+         function(k) {
+            return id.match(k) !== null
+         }
+      );
    // If none is found, use the default
    if (typeof template === 'undefined')
       template = 'default';

--- a/autoconfig.js
+++ b/autoconfig.js
@@ -1,0 +1,160 @@
+
+/**
+ * AUTOMATIC TILES
+ * 
+ * Generates a tile object from (id, position, args) tuple.
+ * Uses the logic as explained above for TEMPLATES-FILTERS.
+ */
+function autoTile(id, position, args) {
+   // Match the id against the templates (sorted to match most specific first)
+   var template = Object.keys(TEMPLATES.FILTERS).sort().reverse().find(
+      function(k) {
+         return id.match(k) !== null
+      }
+   );
+   // If none is found, use the default
+   if (typeof template === 'undefined')
+      template = 'default';
+   // If states are available and id is not found there, use 'missing' template
+   if (typeof(angular.element(document.body).scope()) !== 'undefined'
+    && typeof(angular.element(document.body).scope().states[id]) === 'undefined')
+      template = 'missing';
+   // Return the TEMPLATE's resulting tile object
+   return TEMPLATES.FILTERS[template](id, position, args);
+}
+
+/**
+ * AUTOMATIC GROUPS
+ * 
+ * This function takes a group object with an array of tile stubs and 
+ * generates a proper "items" list with proper "tile" objects from it.
+ * The stubs should be arranged in a matrix as follows:
+ *   [
+ *     ['sun.sun', , 'sensor.uptime'   ]
+ *     [         , , 'group.all_lights']
+ *   ]
+ * Each stub can be a simple entity_id. Then, the TEMPLATES above are used.
+ * If the stub is a dictionary, its "id" element is used as "id" and the rest is merged.
+ * The "position" element is generated autmatically, but can be (uselessly) overriden by
+ * defining it in the stub.
+ *
+ * Each row of tiles is wrapped, in order to respect the group's "width" property,
+ * if provided. As a side effect, you can provide only one long row of tile stubs and
+ * the tiles will be arranged to match the group's "width" property.
+ *
+ * Take care to provide a double array (i.e. [[...]]) as items!
+ */
+
+function autoGroup(group) {
+   // Stash items
+   var items = group.items || [[]];
+   group.items = [];
+   // Calculate size
+   var width = group.width 
+            || Math.max.apply(Math,
+                  items.map(function(e){ return e.length})
+               )
+            || 0;
+   // Loop items
+   var x = 0;
+   var y = -1;
+   var tile = {};
+   for (row of items) {
+      x = 0; y += 1;
+      for (item of row) {
+         //Noty.addObject({title: item});
+         if (x >= width) {
+            x = 0; y += 1; }
+         // Create autoTiles
+         switch (typeof item) {
+            case 'undefined':
+               x += 1;
+               continue;
+            case 'string':
+               tile = autoTile(item, [x,y], {});
+               break;
+            default:
+               tile = autoTile(item.id, [x,y], item);
+         }
+         x += tile.width || 1;
+         // Push tile to next row, if needed
+         if (x > width) {
+            tile.position = [0, y+1];
+            x = tile.width; y += 1;
+         }
+         // Append tile to group's items
+         group.items.push(tile);
+      }
+   }
+   // Return group object
+   group.width  = group.width  || Math.min(width, group.items.length);
+   group.height = group.height || y+1;
+   return group;
+}
+
+/**
+ * IMPORT GROUP
+ * 
+ * In addition to autoGroup (see above) this function also fills some 
+ * group properties automatically from the HA group identified as group.id.
+ */
+
+function importGroup(group, states) {
+   if (typeof states == 'undefined')
+      states = angular.element(document.body).scope().states;
+   group.title = group.title 
+              ||  states[group.id].attributes.friendly_name;
+   group.items = group.items
+              || [states[group.id].attributes.entity_id];
+   return autoGroup(group);
+}
+
+/**
+ * IMPORT PAGE
+ * 
+ * This function imports a complete group from HA as a page into TileBoard.
+ * This is most useful for groups with view=true in HA. Provide the entity id
+ * as page.id.
+ */
+
+function importPage(page, states) {
+   if (typeof states == 'undefined')
+      states = angular.element(document.body).scope().states;
+   // Import some simple properties 
+   page.title = page.title
+             || states[page.id].attributes.friendly_name;
+   page.icon = page.icon
+             || states[page.id].attributes.icon.replace(':','-');
+   page.bg = page.bg || 'images/bg1.jpeg';
+   page.width = page.width || 3;
+   page.groups = page.groups || [];
+   // Take care of states not in sub-groups
+   page.groups.push({
+      width: page.width,
+      title: 'Loose items',
+      items: [[]]
+   });
+   var loose_index = page.groups.length-1;
+   // Loop all entities in the page.id
+   states[page.id].attributes.entity_id.forEach(function(id) {
+      // If a group: import the group
+      if (id.match('group.')) {
+         page.groups.push(importGroup({
+            id: id,
+            width: page.width
+         }));
+      // If not: add to loose items
+      } else {
+         page.groups[loose_index].items[0].push(id);
+      }
+   });
+   // Remove or autoGroup the loose items
+   if (page.groups[loose_index].items[0].length > 0) {
+      page.groups[loose_index] = autoGroup(page.groups[loose_index]);
+   } else {
+      page.groups.splice(loose_index,1);
+   }
+   // Return the page object
+   return page;
+}
+

--- a/config.js
+++ b/config.js
@@ -1,0 +1,16 @@
+/**
+ * AUTOMATOC CONFIGURATION
+ *
+ * This is stored outside of config.js to increase
+ * readability. But this means, we also have to move
+ * the CONFIG var to here:
+ *   variable.js 
+ */
+[
+   'templates.js',
+   'autoconfig.js',
+   'variable.js',
+].map(function (value) {
+   document.write('<sc'+'ript src="'+value+suffix+'"></scr'+'ipt>');
+});
+

--- a/templates.js
+++ b/templates.js
@@ -1,0 +1,140 @@
+
+/**
+ * TEMPLATES FOR TILES
+ * 
+ * The variable TEMPLATES.FILTERS holds a dictionary of this type:
+ *   PATTERN: TEMPLATE_FUNCTION(id, position, args)
+ * The patterns are matched against the entity_id to generate a tile for.
+ * The id and the position are passed to the TEMPLATE_FUNCTION. 
+ * Additional arguments can be passed as args and will be merged into the tile.
+ *
+ * You can extend the TEMPLATES.FILTERS variable simply by doing the following:
+ *   TEMPLATES.FILTERS['my_id'] = MY_TEMPLATE_FUNCTION;
+ */
+var TEMPLATES = {FILTERS: {}};
+
+// DEFAULT: Special template to be used as a default
+// Simply apply the arguments and use the domain as type..
+TEMPLATES.DEFAULT = function(id, position, args){
+   return angular.merge({
+      id: id,
+      position: position,
+      type: TYPES[id.split('.', 1)[0].toUpperCase()]
+   }, args);
+};
+
+// MISSING: Special template for unfound entity_id's
+// Simply use a text field...
+TEMPLATES.MISSING = function(id, position, args){
+   return angular.merge({
+      type: TYPES.TEXT_LIST,
+                     id: {}, // using empty object for an unknown id
+                     position: position,
+                     state: false, // disable state element
+                     list: [
+                        {
+                           title: 'Missing',
+                           icon: 'mdi-clock-outline',
+                           value: id
+                        }
+                     ]
+   }, args);
+};
+
+// FILTERS: This is the actual dictionary queried by the autoTile function
+TEMPLATES.FILTERS = {
+   'default':                      TEMPLATES.DEFAULT,      // Special template to be used as a default
+   'missing':                      TEMPLATES.MISSING,      // Special template for unfound entity_id's
+};
+
+// MEDIA_PLAYER: Example how to extend the template filters
+TEMPLATES.MEDIA_PLAYER = function(id,position,args){
+   return angular.merge({
+   position: position,
+   id: id,
+   width: 2,
+   type: TYPES.MEDIA_PLAYER,
+   hideSource: false,
+   hideMuteButton: false,
+   state: false,
+   //state: '@attributes.media_title',
+   subtitle: '@attributes.media_title',
+   bgSuffix: '@attributes.entity_picture',
+},args);
+};
+TEMPLATES.FILTERS['media_player.'] = TEMPLATES.MEDIA_PLAYER;
+
+// SNAPCLIENT: Use a switch/dimmer with plus/minus buttons for volume control
+// Note: Also the MEDIA_PLAYER does most of these things. And provides a slider!
+TEMPLATES.SNAPCLIENT = function(id, position, args) {
+   return angular.merge({
+      id: id,
+      position: position,
+      title: function (item, entity) { // remove the word snapclient from friendly_name
+         return entity.attributes.friendly_name.replace('snapclient ', '');
+      },
+      subtitle: 'Snapclient',
+      type: TYPES.DIMMER_SWITCH, // TYPES.LIGHT would allow for long-press sliders but has hardcoded things there...
+      state: function (item, entity) { // use 'off', 'muted', or '...%'
+         return entity.state === 'off' ? 'off'
+              : entity.attributes.is_volume_muted ? 'muted' 
+              : (entity.attributes.volume_level*100).toString() + '%';
+      },
+      icon: function (item, entity) { // use mdi-volume-*
+         return entity.attributes.is_volume_muted    ? 'mdi-volume-mute'
+              : entity.attributes.volume_level < 0.5 ? 'mdi-volume-low'
+              : entity.attributes.volume_level < 1.0 ? 'mdi-volume-medium'
+              : 'mdi-volume-high';
+      },
+      action: function(item, entity) { // toggle mute
+         Api.send({
+           type: "call_service",
+           domain: 'media_player',
+           service: "volume_mute",
+           service_data: {
+             entity_id: item.id,
+             is_volume_muted: !entity.attributes.is_volume_muted
+           }
+         });
+      },
+      actionPlus: function(item, entity) { // incease volume by 10%
+         Api.send({
+           type: "call_service",
+           domain: 'media_player',
+           service: "volume_set",
+           service_data: {
+             entity_id: item.id,
+             volume_level: Math.max(0.0, Math.min(1.0, entity.attributes.volume_level + 0.1))
+           }
+         });
+      },
+      actionMinus: function(item, entity) { // decrease volume by 10%
+         Api.send({
+           type: "call_service",
+           domain: 'media_player',
+           service: "volume_set",
+           service_data: {
+             entity_id: item.id,
+             volume_level: Math.max(0.0, Math.min(1.0, entity.attributes.volume_level - 0.1))
+           }
+         });
+      },
+      /* This would work for TYPES.LIGHT only...      
+      sliders: [{
+         title: 'Volume',
+         field: 'volume_level',
+         max:  1.0,
+         min:  0.0,
+         step: 0.1,
+         request: {
+            type: "call_service",
+            domain: "media_player",
+            service: "volume_set",
+            field: "volume_level"
+         }
+      }],
+      colorpicker: false
+      */
+   }, args);
+};
+TEMPLATES.FILTERS['media_player.snapcast_client'] = TEMPLATES.SNAPCLIENT;

--- a/templates.js
+++ b/templates.js
@@ -17,9 +17,9 @@ var TEMPLATES = {FILTERS: {}};
 // Simply apply the arguments and use the domain as type..
 TEMPLATES.DEFAULT = function(id, position, args){
    return angular.merge({
-      id: id,
+      id:   id ? id : {},
+      type: id ? TYPES[id.split('.', 1)[0].toUpperCase()] : {},
       position: position,
-      type: TYPES[id.split('.', 1)[0].toUpperCase()]
    }, args);
 };
 
@@ -63,6 +63,38 @@ TEMPLATES.MEDIA_PLAYER = function(id,position,args){
 },args);
 };
 TEMPLATES.FILTERS['media_player.'] = TEMPLATES.MEDIA_PLAYER;
+
+// INPUT_SELECT, SENSOR, SCENE: No state, because duplicated
+TEMPLATES.FILTERS['input_select.'] = function(id, position, args) {
+   return angular.merge(
+      TEMPLATES.DEFAULT(id, position, {
+         state: false,
+   }),args);
+};
+TEMPLATES.FILTERS['sensor.'] = TEMPLATES.FILTERS['input_select.'];
+TEMPLATES.FILTERS['scene.']  = TEMPLATES.FILTERS['input_select.'];
+
+// SCRIPT: Try to use icon
+TEMPLATES.FILTERS['script.'] = function(id, position, args) {
+   return angular.merge(
+      TEMPLATES.DEFAULT(id, position, {
+         icon: function (item, entity) {
+            return entity.attributes.icon.replace(':','-');
+         },
+   }),args);
+};
+
+// LIGHT/SWITCH: Have an icon to show on/off state
+TEMPLATES.FILTERS['light.'] = function(id, position, args) {
+   return angular.merge(
+      TEMPLATES.DEFAULT(id, position, {
+         icons: {
+            'on':  'mdi-lightbulb-on-outline',
+            'off': 'mdi-lightbulb-off-outline',
+         }
+   }),args);
+};
+TEMPLATES.FILTERS['switch.'] = TEMPLATES.FILTERS['light.'];
 
 // SNAPCLIENT: Use a switch/dimmer with plus/minus buttons for volume control
 // Note: Also the MEDIA_PLAYER does most of these things. And provides a slider!

--- a/variable.js
+++ b/variable.js
@@ -1,0 +1,341 @@
+
+/**
+ * AUTOMATIC TILE SIZING
+ *
+ * Calculates tile size automatically for different screensizes.
+ */
+
+var groupWidth = 3; // count of tiles horizontally
+var tileMargin = 5; // px
+var groupMargin = 5; // px
+var maxTileSize = 150; // px
+
+var tileSize = getTileSize(groupWidth, tileMargin, groupMargin, maxTileSize);
+
+function getTileSize (groupWidth, tileMargin, groupMargin, maxTileSize) {
+   var width = window.innerWidth;
+   width -= groupMargin * 2 + tileMargin * (groupWidth - 1);
+   return Math.min(maxTileSize, +(width / groupWidth).toFixed(1));
+}
+
+
+
+/**
+ * AUTOMATIC CONFIGURATION LOADING
+ * 
+ * The following snippet updates the configuration with an automatically
+ * generated one, as soon as the Api is available.
+ */
+
+// When the body has finished loading
+angular.element(document.body).ready(function (){
+   // Wait also for the Api to be ready
+   Api.onReady(function() {
+      // Read out the states from HA and do the magic
+      Api.getStates(function(res) {
+         // The states from HA need some reordering to be useful
+         var states = {};
+         res.result.forEach(function (state) {
+            states[state.entity_id] = state;
+         });
+         // The $scope variables is where TileBoard loads its views from
+         var $scope = angular.element(document.body).scope();
+         // Import a group like this:
+         $scope.pages[0].groups.unshift(importGroup({
+            id: 'group.all_scripts',
+            width: 3
+            }, states));
+         // Import a complete view as a page like this:
+         $scope.pages.push(importPage({
+            id: 'group.default_view'
+            }, states));
+         // Finally call the view:updated trigger to, well, update the view
+         angular.element(window).triggerHandler('view:updated'); 
+      });
+   });
+});
+
+var CONFIG = {
+   customTheme: null, // CUSTOM_THEMES.TRANSPARENT, CUSTOM_THEMES.MATERIAL, CUSTOM_THEMES.MOBILE, CUSTOM_THEMES.COMPACT, CUSTOM_THEMES.HOMEKIT, CUSTOM_THEMES.WINPHONE, CUSTOM_THEMES.WIN95
+   transition: TRANSITIONS.ANIMATED_GPU, //ANIMATED or SIMPLE (better perfomance)
+   entitySize: ENTITY_SIZES.NORMAL, //SMALL, BIG are available
+   tileSize: 150,
+   tileMargin: 6,
+   serverUrl: "https://"+window.location.hostname+":8123",
+   wsUrl: "wss://"+window.location.hostname+":8123/api/websocket",
+   authToken: null, // optional long-lived token (CAUTION: only if TileBoard is not exposed to the internet)
+   //googleApiKey: "XXXXXXXXXX", // Required if you are using Google Maps for device tracker
+   //mapboxToken: "XXXXXXXXXX", // Required if you are using Mapbox for device tracker
+   debug: false, // Prints entities and state change info to the console.
+   pingConnection: true, //ping connection to prevent silent disconnections
+
+   // next fields are optional
+   events: [],
+   timeFormat: 24,
+   menuPosition: MENU_POSITIONS.LEFT, // or BOTTOM
+   hideScrollbar: false, // horizontal scrollbar
+   groupsAlign: GROUP_ALIGNS.HORIZONTALLY, // or VERTICALLY
+
+   header: { // https://github.com/resoai/TileBoard/wiki/Header-configuration
+      styles: {
+         padding: '30px 130px 0',
+         fontSize: '28px'
+      },
+      right: [],
+      left: [
+         {
+            type: HEADER_ITEMS.DATETIME,
+            dateFormat: 'EEEE, LLLL dd', //https://docs.angularjs.org/api/ng/filter/date
+         }
+      ]
+   },
+
+   /*screensaver: {// optional. https://github.com/resoai/TileBoard/wiki/Screensaver-configuration
+      timeout: 300, // after 5 mins of inactive
+      slidesTimeout: 10, // 10s for one slide
+      styles: { fontSize: '40px' },
+      leftBottom: [{ type: SCREENSAVER_ITEMS.DATETIME }], // put datetime to the left-bottom of screensaver
+      slides: [
+         { bg: 'images/bg1.jpeg' },
+         {
+            bg: 'images/bg2.png',
+            rightTop: [ // put text to the 2nd slide
+               {
+                  type: SCREENSAVER_ITEMS.CUSTOM_HTML,
+                  html: 'Welcome to the <b>TileBoard</b>',
+                  styles: { fontSize: '40px' }
+               }
+            ]
+         },
+         { bg: 'images/bg3.jpg' }
+      ]
+   },*/
+
+   pages: [
+      {
+         title: 'Main page',
+         bg: 'images/bg1.jpeg',
+         icon: 'mdi-home-outline', // home icon
+         groups: [
+            {
+               title: 'First group',
+               width: 2,
+               height: 3,
+               items: [
+                  {
+                     position: [0, 0],
+                     width: 2,
+                     type: TYPES.TEXT_LIST,
+                     id: {}, // using empty object for an unknown id
+                     state: false, // disable state element
+                     list: [
+                        {
+                           title: 'Sun.sun state',
+                           icon: 'mdi-weather-sunny',
+                           value: '&sun.sun.state'
+                        },
+                        {
+                           title: 'Custom',
+                           icon: 'mdi-clock-outline',
+                           value: 'value'
+                        }
+                     ]
+                  },
+                  {
+                     position: [0, 1], // [x, y]
+                     width: 1,
+                     type: TYPES.SENSOR,
+                     id: 'updater.updater',
+                     state: '@attributes.release_notes' // https://github.com/resoai/TileBoard/wiki/Templates
+                  }
+               ]
+            },
+
+            {
+               title: 'Second group',
+               width: 2,
+               height: 3,
+               items: [
+                  {
+                     position: [0, 0],
+                     width: 1,
+                     type: TYPES.SLIDER,
+                     //id: "input_number.volume",
+                     id: {state: 50}, // replace it with real string id
+                     state: false,
+                     title: 'Custom slider',
+                     subtitle: 'Example of subtitle',
+                     slider: {
+                        min: 0,
+                        max: 100,
+                        step: 2,
+                        request: {
+                           type: "call_service",
+                           domain: "input_number",
+                           service: "set_value",
+                           field: "value"
+                        }
+                     }
+                  },
+                  {
+                     position: [1, 0],
+                     width: 1,
+                     type: TYPES.SWITCH,
+                     //id: "switch.lights",
+                     id: {state: 'off'}, // replace it with real string id (e.g. "switch.lights")
+                     state: false,
+                     title: 'Custom switch',
+                     icons: {'off': 'mdi-volume-off', 'on': 'mdi-volume-high'}
+                  },
+                  {
+                     position: [0, 1],
+                     type: TYPES.ALARM,
+                     //id: "alarm_control_panel.home_alarm",
+                     id: { state: 'disarmed' }, // replace it with real string id
+                     title: 'Home Alarm',
+                     icons: {
+                        disarmed: 'mdi-bell-off',
+                        pending: 'mdi-bell',
+                        armed_home: 'mdi-bell-plus',
+                        armed_away: 'mdi-bell',
+                        triggered: 'mdi-bell-ring'
+                     },
+                     states: {
+                        disarmed: 'Disarmed',
+                        pending: 'Pending',
+                        armed_home: 'Armed home',
+                        armed_away: 'Armed away',
+                        triggered: 'Triggered'
+                     }
+                  }
+
+               ]
+            },
+
+            {
+               title: '',
+               width: 1,
+               height: 3,
+               items: [
+                  {
+                     // please read README.md for more information
+                     // this is just an example
+                     position: [0, 0],
+                     height: 2, // 1 for compact
+                     //classes: ['-compact'],
+                     type: TYPES.WEATHER,
+                     id: {},
+                     state: function () {return 'Sunny'}, // https://github.com/resoai/TileBoard/wiki/Anonymous-functions
+                     icon: 'clear-day',
+                     icons: { 'clear-day': 'clear'},
+                     fields: {
+                        summary: 'Sunny',
+                        temperature: '18',
+                        temperatureUnit: 'C',
+                        windSpeed: '5',
+                        windSpeedUnit: 'kmh',
+                        humidity: '50',
+                        humidityUnit: '%',
+                        list: [
+                           'Feels like 16 C'
+                           /*
+                           'Feels like '
+                              + '&sensor.dark_sky_apparent_temperature.state'
+                              + '&sensor.dark_sky_apparent_temperature.attributes.unit_of_measurement',
+                           'Pressure '
+                              + '&sensor.dark_sky_pressure.state'
+                              + '&sensor.dark_sky_pressure.attributes.unit_of_measurement',
+                           '&sensor.dark_sky_precip_probability.state'
+                              + '&sensor.dark_sky_precip_probability.attributes.unit_of_measurement'
+                              + ' chance of rain'
+                           */
+                        ]
+                     }
+                  }
+
+               ]
+            },
+            autoGroup({ // use autoGroup() to automatically arrange tiles in a group
+               title: 'autoGroup(...) and friends',
+               items:
+               [
+                  ['sun.sun',                  , 'sensor.uptime'   ],
+                  [         , 'updater.updater',                   ],
+                  [
+                     TEMPLATES.SNAPCLIENT('media_player.snapcast_client_00_00_00_00_00_00',[]), // use template functions to make your life easier
+                     autoTile            ('media_player.snapcast_client_00_00_00_00_00_00',[]), // use autoTile() to select the right template for you 
+                  ]
+               ]
+            }),
+         ]
+      },
+      {
+         title: 'Second page',
+         bg: 'images/bg2.png',
+         icon: 'mdi-numeric-2-box-outline',
+         groups: [
+            {
+               title: '',
+               width: 2,
+               height: 3,
+               items: [
+                  {
+                     position: [0, 0],
+                     width: 2,
+                     title: 'Short instruction',
+                     type: TYPES.TEXT_LIST,
+                     id: {}, // using empty object for an unknown id
+                     state: false, // disable state element
+                     list: [
+                        {
+                           title: 'Read',
+                           icon: 'mdi-numeric-1-box-outline',
+                           value: 'README.md'
+                        },
+                        {
+                           title: 'Ask on forum',
+                           icon: 'mdi-numeric-2-box-outline',
+                           value: 'home-assistant.io'
+                        },
+                        {
+                           title: 'Open an issue',
+                           icon: 'mdi-numeric-3-box-outline',
+                           value: 'github.com'
+                        }
+                     ]
+                  },
+                  {
+                     position: [0, 1.5],
+                     width: 1.5,
+                     height: 1,
+                     title: 'My Gauge Title',
+                     subtitle: '',
+                     type: TYPES.GAUGE,
+                     id: 'sensor.my_sample_sensor', // Assign the sensor you want to display on the gauge
+                     value: function(item, entity) {
+                        return entity.state;
+                     },
+                     settings: {
+                        size: 200, // Defaults to 50% of either height or width, whichever is smaller
+                        type: 'full', // Options are: 'full', 'semi', and 'arch'. Defaults to 'full'
+                        min: 0, // Defaults to 0
+                        max: 25000, // Defaults to 100
+                        cap: 'round', // Options are: 'round', 'butt'. Defaults to 'butt'
+                        thick: 8, // Defaults to 6
+                        label: 'My Gauge', // Defaults to undefined
+                        append: '@attributes.unit_of_measurement', // Defaults to undefined
+                        prepend: '$', // Defaults to undefined
+                        duration: 1500, // Defaults to 1500ms
+                        thresholds: { 0: { color: 'green'}, 80: { color: 'red' } }, // Defaults to undefined
+                        labelOnly: false, // Defaults to false
+                        foregroundColor: 'rgba(0, 150, 136, 1)', // Defaults to rgba(0, 150, 136, 1)
+                        backgroundColor: 'rgba(0, 0, 0, 0.1)', // Defaults to rgba(0, 0, 0, 0.1)
+                        fractionSize: 0, // Number of decimal places to round the number to. Defaults to current locale formatting
+                     },
+                  },
+               ]
+            },
+         ]
+      }
+   ],
+}


### PR DESCRIPTION
As I got confused by all the different braces and did not like to repeatedly define the same options for similar tiles, I set up some auto-configuration functions. I am sure, they will need some more fine-tuning. So, this PR is to start the discussion about it. Right now, I have changed nothing in the original code, but only added things to `config.js`.

What is new here?
* `TEMPLATES` defines functions for common options to repeatedly used tiles.
* `autoTile()` uses these functions automatically based on the entity `id`.
* `autoGroup()` arranges those tiles automatically to a group.
* `importGroup()` imports a group from the HA states.
* `importPage()` imports a whole page from the HA states (group with `view=true`).

The functionality is split up in four files:
* `config.js` only imports the remaining three files.
* `templates.js` defines the `TEMPLATES`.
* `autoconfig.js` defines the functions explained above.
* `variable.js` is the new `config.js`. I couldn't think of a better name...

Finally, in `variable.js` there are snippets, showing how to 
* use the templates
* use the `auto*` functions (may be done on init of TileBoard)
* use the `import*` functions (must be done after the `HApi` is available).

