### PR TITLE
Fix item's state behavior

### DIFF
--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -451,32 +451,31 @@ function MainController ($scope, $location) {
    $scope.entityState = function (item, entity) {
       if(item.state === false) return null;
 
-      var res;
-
-      if(item.state) {
+      if(typeof item.state != 'undefined') {
          if(typeof item.state === "string") {
             return parseString(item.state, entity);
          }
          else if(typeof item.state === "function") {
-            res = callFunction(item.state, [item, entity]);
-            if(res) return res;
+            return callFunction(item.state, [item, entity]);
+         }
+         else {
+            return item.state;
          }
       }
 
-      if(item.states) {
+      if(typeof item.states != 'undefined') {
          if(typeof item.states === "function") {
-            res = callFunction(item.states, [item, entity]);
+            return callFunction(item.states, [item, entity]);
          }
          else if(typeof item.states === "object") {
-            res = item.states[entity.state] || entity.state;
+            return item.states[entity.state] || entity.state;
          }
-
-         if(res) return res;
+         else {
+            return item.states;
+         }
       }
 
-      if(!item.state) return entity.state;
-
-      return item.state;
+      return entity.state;
    };
 
    $scope.entityIcon = function (item, entity) {

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -451,7 +451,7 @@ function MainController ($scope, $location) {
    $scope.entityState = function (item, entity) {
       if(item.state === false) return null;
 
-      if(typeof item.state != 'undefined') {
+      if(typeof item.state !== 'undefined') {
          if(typeof item.state === "string") {
             return parseString(item.state, entity);
          }
@@ -463,16 +463,11 @@ function MainController ($scope, $location) {
          }
       }
 
-      if(typeof item.states != 'undefined') {
-         if(typeof item.states === "function") {
-            return callFunction(item.states, [item, entity]);
-         }
-         else if(typeof item.states === "object") {
-            return item.states[entity.state] || entity.state;
-         }
-         else {
-            return item.states;
-         }
+      if(typeof item.states === "function") {
+         return callFunction(item.states, [item, entity]);
+      }
+      else if(typeof item.states === "object") {
+         return item.states[entity.state] || entity.state;
       }
 
       return entity.state;


### PR DESCRIPTION
This alters the `item.state(s)` fallback logic, in order for the following to work:

```
state: function (item, entity) {
   return entity.attributes.can_cancel ? entity.state : null;
},
```

The purpose is to remove the state field from tiles of one-shot scripts, which have no meaningful state.

The new fallback falls in line with the 'highly customizable' objective of TileBoard:
* if the user provides `state` or `states`, the field is used - no matter what, so also `null`, `false`, `{}` or similar results.
* if the user provides sth, which is not a function, string or object, it is simply passed on as the state.
* if none of the fields are provided, the `entity.state` is returned.

I believe this is very similar to the old logic, but more consistent and more customizable. However, people might have relied on the old behavior; e.g. (whyever) providing `state` and `states` together using the latter as a fallback for empty result of the former.

For you to decide, if this change is useful. I believe it is - for the sake of consistency and customizablility. Hence the PR. ;-)