### PR TITLE
Don't clear access token on intermittent connection problem

### DIFF
--- a/scripts/models/api.js
+++ b/scripts/models/api.js
@@ -268,13 +268,18 @@ var HApi = (function () {
       xhr.send(url + '&client_id=' + getOAuthClientId());
 
       xhr.onreadystatechange = function() {
-         if(xhr.status !== 200) {
-            redirectOAuth();
-            callback(null);
-         }
+         if(xhr.readyState !== XMLHttpRequest.DONE) return;
 
-         if(xhr.readyState === 4) {
+         if(xhr.status === 200) {
             callback(JSON.parse(xhr.response));
+            return;
+         }
+         else if(xhr.status >= 400 && xhr.status < 500) {  // authentication error
+            redirectOAuth();
+            return;
+         }
+         else {
+            callback(null);
          }
       };
    };
@@ -301,6 +306,11 @@ var HApi = (function () {
       var url = 'grant_type=refresh_token&refresh_token=' + token.refresh_token;
 
       this._request(url, function (data) {
+         if(!data) {
+            callback(null);
+            return;
+         }
+
          data.refresh_token = token.refresh_token;
 
          saveToken(data);
@@ -313,6 +323,11 @@ var HApi = (function () {
       var url = 'grant_type=authorization_code&code=' + code;
 
       this._request(url, function (data) {
+         if(!data) {
+            callback(null);
+            return;
+         }
+
          saveToken(data);
 
          callback(data);


### PR DESCRIPTION
When HomeAssistant is restarting or just there is a problem with
connection, TileBoard assumed that user needs to get authenticated
and tried to fetch new token after deleting current one.

Don't do that unless the response code is in 4xx range.
Per HomeAssistant documentation[1], it will return 400, 401 or 403
when token is expired or there is other authentication error.

Also don't react to state changes until response is in DONE state.

[1] https://developers.home-assistant.io/docs/en/auth_api.html#making-authenticated-requests