### PR TITLE
Allow override of `item.action` and `item.longClickAction`

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,18 @@ Tile Object. [Click here for some real life examples](TILE_EXAMPLES.md)
    */
   icon: 'mdi-phone'
 
+  /* action: Define a custom action on click
+   * You can override the default action for any tile type.
+   * This function will be evaluated, when the user clicks the tile.
+   */
+  action: function(item, entity) {return this.$scope.openPopupIframe(item, entity);}
+
+  /* longPressAction: Define a custom action on long press
+   * You can override the default action for any tile type.
+   * This function will be evaluated, when the user long-presses the tile.
+   */
+  longPressAction: function(item, entity) {return this.$scope.openPopupIframe(item, entity);}
+
   /* bg: Link to a background image for the tile
    * @ and & prefixes are explained below
    */

--- a/README.md
+++ b/README.md
@@ -286,11 +286,11 @@ Tile Object. [Click here for some real life examples](TILE_EXAMPLES.md)
    */
   action: function(item, entity) {return this.$scope.openPopupIframe(item, entity);}
 
-  /* longPressAction: Define a custom action on long press
-   * You can override the default action for any tile type.
+  /* secondaryAction: Define a custom secondary action (on long press)
+   * You can override the default secondary action for any tile type.
    * This function will be evaluated, when the user long-presses the tile.
    */
-  longPressAction: function(item, entity) {return this.$scope.openPopupIframe(item, entity);}
+  secondaryAction: function(item, entity) {return this.$scope.openPopupIframe(item, entity);}
 
   /* bg: Link to a background image for the tile
    * @ and & prefixes are explained below

--- a/TILE_EXAMPLES.md
+++ b/TILE_EXAMPLES.md
@@ -80,7 +80,7 @@ Manually trigger an automation
 ```
 
 #### CUSTOM
-The custom tile type allows you to fire javascript commands on click/tap.
+The custom tile type does not have handling for any specific entity types. It can be used to, for example, trigger custom actions on pressing.
 
 ![CUSTOM](images/tile-screenshots/CUSTOM.png)
 
@@ -93,6 +93,9 @@ The custom tile type allows you to fire javascript commands on click/tap.
    icon: 'mdi-monitor',
    action: function(item, entity) {
         fully.startScreensaver();
+   },
+   secondaryAction: function(item, entity) {
+      return this.$scope.openPopupIframe(item, entity);
    }
 },
 ```

--- a/index.html
+++ b/index.html
@@ -453,7 +453,7 @@
 <script type="text/ng-template" id="tile.html">
    <div ng-style="itemStyles(page, item, entity)" class="item"
         ng-click="entityClick(page, item, entity)"
-        hm-press="entityLongClick($event, page, item, entity)"
+        hm-press="entityLongPress($event, page, item, entity)"
         hm-recognizer-options="{time: 600}"
         ng-if="(entity = getItemEntity(item)) && !isHidden(item, entity)"
         ng-class="itemClasses(item)">

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -75,8 +75,8 @@ function MainController ($scope, $location) {
    };
 
    $scope.entityLongClick = function ($event, page, item, entity) {
-      if(typeof item.longClickAction === "function") {
-         return callFunction(item.longClickAction, [item, entity]);
+      if(typeof item.longPressAction === "function") {
+         return callFunction(item.longPressAction, [item, entity]);
       }
 
       switch (item.type) {

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -74,7 +74,7 @@ function MainController ($scope, $location) {
       }
    };
 
-   $scope.entityLongClick = function ($event, page, item, entity) {
+   $scope.entityLongPress = function ($event, page, item, entity) {
       if(typeof item.longPressAction === "function") {
          return callFunction(item.longPressAction, [item, entity]);
       }

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -75,8 +75,8 @@ function MainController ($scope, $location) {
    };
 
    $scope.entityLongPress = function ($event, page, item, entity) {
-      if(typeof item.longPressAction === "function") {
-         return callFunction(item.longPressAction, [item, entity]);
+      if(typeof item.secondaryAction === "function") {
+         return callFunction(item.secondaryAction, [item, entity]);
       }
 
       switch (item.type) {

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -36,6 +36,10 @@ function MainController ($scope, $location) {
    var popupIframeStyles = {};
 
    $scope.entityClick = function (page, item, entity) {
+      if(typeof item.action === "function") {
+         return callFunction(item.action, [item, entity]);
+      }
+
       switch (item.type) {
          case TYPES.SWITCH:
          case TYPES.LIGHT:
@@ -62,7 +66,6 @@ function MainController ($scope, $location) {
 
          case TYPES.ALARM: return $scope.openAlarm(item, entity);
 
-         case TYPES.CUSTOM: return $scope.customTileAction(item, entity);
          case TYPES.DIMMER_SWITCH: return $scope.dimmerToggle(item, entity);
 
          case TYPES.POPUP_IFRAME: return $scope.openPopupIframe(item, entity);
@@ -72,6 +75,10 @@ function MainController ($scope, $location) {
    };
 
    $scope.entityLongClick = function ($event, page, item, entity) {
+      if(typeof item.longClickAction === "function") {
+         return callFunction(item.longClickAction, [item, entity]);
+      }
+
       switch (item.type) {
          case TYPES.LIGHT: return $scope.openLightSliders(item, entity);
       }
@@ -1064,12 +1071,6 @@ function MainController ($scope, $location) {
             entity_id: item.id
          }
       });
-   };
-
-   $scope.customTileAction = function (item, entity) {
-      if(item.action && typeof item.action === "function") {
-         callFunction(item.action, [item, entity]);
-      }
    };
 
    $scope.sendPlayer = function (service, item, entity) {


### PR DESCRIPTION
This caters for ideas as described in #274. If we can always override the `item`'s `action` or `longPressAction` we can make more fancy things. And TileBoard becomes actually more "customizable".