### PR TITLE
Fix points not showing up when hovering chart values

### DIFF
--- a/scripts/init.js
+++ b/scripts/init.js
@@ -54,7 +54,10 @@ App.config(function($sceProvider, $locationProvider, ApiProvider, ChartJsProvide
       tooltips: {
          mode: 'index',
          intersect: false
-      }
+      },
+      hover: {
+        mode: 'index',
+        intersect: false
+      },
    });
-
 });


### PR DESCRIPTION
Use same settings for both "tooltips" and "hover" so that when tooltip
is shown for certain data point, also the "point" for it is showing up.
@akloeckner 