### PR TITLE
Support multiple entities in charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,11 +382,11 @@ Tile Object. [Click here for some real-life examples](TILE_EXAMPLES.md)
     * as a function function (item, entity) { return { 'background-color': '#FF0000' } }
     * (optional)
     */
-   customStyles: Object || Function
+   customStyles: Object || Function,
 
    /* Object containing history settings */
    history: { // If this is present in a tile, a history popup is created on secondary action
-      entity: 'sensor.temperatur_innen_gefiltert', // Entity ID to render history for. Default: entity id of the tile itself
+      entity: 'sensor.temperatur_innen_gefiltert', // Entity ID (or an array of IDs) to render history for. Default: entity id of the tile itself
       offset: 24*3600*1000*5, // Start point of the history counting from now(). Default: one day
       options: { elements: {point: {radius: 3}}}, // Chart options. Refer to https://www.chartjs.org/.
       styles: { border: '1px solid red'}, // Styles to apply to the <div> containng the chart. Default according to main.css

--- a/index.html
+++ b/index.html
@@ -146,8 +146,7 @@
                <canvas id="history-popup--canvas"
                   class="chart chart-line"
                   chart-data="activeHistory.data"
-                  chart-labels="activeHistory.labels"
-                  chart-series="activeHistory.series"
+                  chart-dataset-override="activeHistory.datasetOverride"
                   chart-options="activeHistory.options"></canvas>
             </div>
          </div>

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -41,6 +41,7 @@ App.config(function($sceProvider, $locationProvider, ApiProvider, ChartJsProvide
       elements: { 
          point: { 
             radius: 0, // to remove points
+            hitRadius: 5
          },
          line: {
             borderWidth: 1,
@@ -52,11 +53,9 @@ App.config(function($sceProvider, $locationProvider, ApiProvider, ChartJsProvide
          display: true
       },
       tooltips: {
-         mode: 'index',
          intersect: false
       },
       hover: {
-        mode: 'index',
         intersect: false
       },
    });

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -24,6 +24,13 @@ App.config(function($sceProvider, $locationProvider, ApiProvider, ChartJsProvide
 
    ChartJsProvider.setOptions('line', {
       maintainAspectRatio: false, // to fit popup automatically
+      layout: {
+         padding: {
+            bottom: 10,
+            left: 10,
+            right: 10
+         }
+      },
       scales: {
          xAxes: [{
             type: 'time',
@@ -59,4 +66,7 @@ App.config(function($sceProvider, $locationProvider, ApiProvider, ChartJsProvide
         intersect: false
       },
    });
+
+   // Workaround to add padding around legend.
+   Chart.Legend.prototype.afterFit = function() { this.height += 20; };
 });

--- a/scripts/models/api.js
+++ b/scripts/models/api.js
@@ -137,7 +137,10 @@ App.provider('Api', function () {
             url: '/api/history/period'
          };
          if (startDate) request.url += '/' + startDate;
-         if (filterEntityId) request.url += '?filter_entity_id=' + filterEntityId;
+         if (filterEntityId) {
+            var entityIds = filterEntityId instanceof Array ? filterEntityId.join(',') : filterEntityId;
+            request.url += '?filter_entity_id=' + entityIds;
+         }
          return this.rest(request);
       };
 


### PR DESCRIPTION
This adds support for showing multiple entities in the chart.
- Nothing should change for single entities
- With multiple entities, all using the same value unit (like degrees or watts), there will be a single y-axis scaled to accommodate all values. That's a perfect case.
 - With multiple entities with different value units or with non-continuous data, there will be multiple y-axes added. That's not an ideal situation and not really possible to handle perfectly. Ideally, there should be multiple graphs created for those cases. But it's sort of usable and if users want to do that, it's up to them, I'd say.
@akloeckner 