### PR TITLE
Improve y-axis legend when on small display

### DIFF
--- a/scripts/init.js
+++ b/scripts/init.js
@@ -44,9 +44,16 @@ App.config(function($sceProvider, $locationProvider, ApiProvider, ChartJsProvide
                },
             },
          }],
+         yAxes: [
+            {
+               ticks: {
+                  maxTicksLimit: 7,
+               },
+            },
+         ],
       },
-      elements: { 
-         point: { 
+      elements: {
+         point: {
             radius: 0, // to remove points
             hitRadius: 5
          },


### PR DESCRIPTION
On a small phone display the y-axis legend was crammed with values:
![Screenshot_20191126-152520_Chrome](https://user-images.githubusercontent.com/153197/69642500-2150bc00-1062-11ea-9b7e-44e56c5a48f2.jpg)

Changed to show less "ticks" so that everything looks nicer (on a big screen things look good also).
![Screenshot_20191126-152951_Chrome](https://user-images.githubusercontent.com/153197/69642587-43e2d500-1062-11ea-823e-b5f94bf9ae5d.jpg)

That value matches what Homeassistant uses (as it also uses Chart.js) so it should be just fine.

@akloeckner 