### PR TITLE
Toggle pages with panning instead of swiping

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
 <body ng-controller="Main" ng-class="getBodyClass()">
 
 <div ng-if="ready" class="page-container"
-     hm-swipe="onPageSwipe($event)"
+     hm-pan="onPagePan($event)"
      hm-recognizer-options="{directions: isMenuOnTheLeft ? 'DIRECTION_VERTICAL' : 'DIRECTION_HORIZONTAL'}"
 >
    <div class="camera-popup"


### PR DESCRIPTION
Panning provides much better and fluid experience and is easier to discover.

I'm quite happy with this change - been using it for some time myself.

There is one thing worth noting about this implementation and related side effect.

On panning, page position is updated (through CSS transform) manually to follow finger motion.
On lifting the finger, I'm finishing the movement using CSS transition.
While that makes implementation much simpler, there is a slightly noticeable "hickup" when that transition happens. It looks a bit like a frame drop. That part could be improved but it would require some fancy math formula to calculate the acc/deceleration of transition instead of relying on CSS transitions. So I'm not sure how worth it is.

Maybe try yourself and check if it's bothersome (now that I mentioned it maybe it will be more than otherwise would be. ;)).