### PR TITLE
Trigger popup history on long press if no other handlers

### DIFF
--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -84,7 +84,11 @@ App.controller('Main', ['$scope', '$timeout', '$location', 'Api', function ($sco
 
       switch (item.type) {
          case TYPES.LIGHT: return $scope.openLightSliders(item, entity);
-         default: return $scope.openPopupHistory(item, entity);
+         default: {
+            if (entity && entity.entity_id) {
+               return $scope.openPopupHistory(item, entity);
+            }
+         }
       }
    };
 

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -84,7 +84,7 @@ App.controller('Main', ['$scope', '$timeout', '$location', 'Api', function ($sco
 
       switch (item.type) {
          case TYPES.LIGHT: return $scope.openLightSliders(item, entity);
-         case TYPES.SENSOR: return $scope.openPopupHistory(item, entity);
+         default: return $scope.openPopupHistory(item, entity);
       }
    };
 


### PR DESCRIPTION
Trigger history popup on long press if entity doesn't have any other handler.

I think it makes sense but you decide.
I like to be able to see history for tiles like "gauge" or even "switch" to be able to see historical/usage data.

@akloeckner 