### PR TITLE
Add support for live camera tiles and video backgrounds.

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -14,6 +14,7 @@ var CONFIG = {
    tileSize: 150,
    tileMargin: 6,
    serverUrl: 'http://' + location.hostname + ':8123',
+   //videoBackground: 'images/christmas.mp4', // use a video as a background. A good place to get videos is https://coverr.co - do not use 'bg' image tag in your pages.
    wsUrl: 'ws://' + location.hostname + ':8123/api/websocket',
    authToken: null, // optional long-lived token (CAUTION: only if TileBoard is not exposed to the internet)
    //googleApiKey: "XXXXXXXXXX", // Required if you are using Google Maps for device tracker

--- a/index.html
+++ b/index.html
@@ -70,9 +70,9 @@
 
 <body ng-controller="Main" ng-class="getBodyClass()">
 
-<div ng-if="CONFIG.videoBackground !== ''">
-   <video loop muted autoplay class="video-background">
-      <source src="{{ CONFIG.videoBackground }}" type="video/mp4">
+<div ng-if="getVideoBackground()" class="video-background">
+   <video loop muted autoplay class="video-background-media">
+      <source src="{{getVideoBackground()}}" type="video/mp4">
    </video>
 </div>
 

--- a/index.html
+++ b/index.html
@@ -869,6 +869,11 @@
          </div>
       </div>
 
+      <div ng-if="item.type === TYPES.CAMERA_STREAM">
+         <camera-stream item="activeCamera.fullscreen" entity="entity"
+            freezed="false"></camera-stream>
+      </div>
+
       <div ng-if="item.type === TYPES.SCENE"
            class="item-entity-container">
 

--- a/index.html
+++ b/index.html
@@ -869,7 +869,8 @@
          </div>
       </div>
 
-      <div ng-if="item.type === TYPES.CAMERA_STREAM">
+      <div ng-if="item.type === TYPES.CAMERA_STREAM"
+           class="item-entity-container -below">
          <camera-stream item="activeCamera.fullscreen" entity="entity"
             freezed="false"></camera-stream>
       </div>

--- a/index.html
+++ b/index.html
@@ -866,7 +866,6 @@
          </div>
       </div>
 
-
       <div ng-if="item.type === TYPES.CAMERA_THUMBNAIL"
            class="item-entity-container -below">
          <div class="item-camera">
@@ -877,7 +876,7 @@
 
       <div ng-if="item.type === TYPES.CAMERA_STREAM"
            class="item-entity-container -below">
-         <camera-stream item="activeCamera.fullscreen" entity="entity"
+         <camera-stream item="item" entity="entity"
             freezed="false"></camera-stream>
       </div>
 

--- a/index.html
+++ b/index.html
@@ -70,6 +70,12 @@
 
 <body ng-controller="Main" ng-class="getBodyClass()">
 
+<div ng-if="CONFIG.videoBackground !== ''">
+   <video loop muted autoplay class="video-background">
+      <source src="{{ CONFIG.videoBackground }}" type="video/mp4">
+   </video>
+</div>
+
 <div ng-if="ready" class="page-container"
      hm-pan="onPagePan($event)"
      hm-recognizer-options="{directions: isMenuOnTheLeft ? 'DIRECTION_VERTICAL' : 'DIRECTION_HORIZONTAL'}"

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -742,6 +742,10 @@ App.controller('Main', ['$scope', '$timeout', '$location', 'Api', function ($sco
       return page.header;
    };
 
+   $scope.getVideoBackground = function () {
+      return CONFIG.videoBackground;
+   }
+
    $scope.getSliderConf = function (item, entity) {
       var key = "_c";
 

--- a/scripts/directives.js
+++ b/scripts/directives.js
@@ -186,6 +186,7 @@ App.directive('cameraStream', ['Api', function (Api) {
          var appendVideo = function (url) {
             var el = document.createElement('video');
             el.style.width = '100%';
+            el.style.height = '100%';
 
             var hls = new Hls();
             hls.loadSource(url);

--- a/styles/main.css
+++ b/styles/main.css
@@ -959,6 +959,39 @@ body {
 .item-select--option.-active {
   background: #666;
 }
+.video-background {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  overflow: hidden;
+  z-index: -100;
+}
+.video-background-media {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+@media (min-aspect-ratio: 16/9) {
+  .video-background-media {
+    height: 300%;
+    top: -100%;
+  }
+}
+@media (max-aspect-ratio: 16/9) {
+  .video-background-media {
+    width: 300%;
+    left: -100%;
+  }
+}
+@media (max-width: 600px) {
+  .video-background-media {
+    display: none;
+  }
+}
 .item-camera {
   width: 100%;
   height: 100%;

--- a/styles/main.less
+++ b/styles/main.less
@@ -1091,6 +1091,46 @@ body {
    }
 }
 
+.video-background {
+   position: fixed;
+   top: 0;
+   right: 0;
+   bottom: 0;
+   left: 0;
+   overflow: hidden;
+   z-index: -100;
+
+   &-media {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      width: 100%;
+      height: 100%;
+   }
+}
+
+@media (min-aspect-ratio: ~"16/9") {
+   .video-background-media {
+      height: 300%;
+      top: -100%;
+   }
+}
+
+@media (max-aspect-ratio: ~"16/9") {
+   .video-background-media {
+      width: 300%;
+      left: -100%;
+   }
+}
+
+@media (max-width: 600px) {
+   .video-background-media {
+      display: none;
+   }
+}
+
 .item-camera {
    width: 100%;
    height: 100%;

--- a/styles/main.less
+++ b/styles/main.less
@@ -1108,26 +1108,17 @@ body {
       height: 100%;
       width: 100%;
       height: 100%;
-   }
-}
-
-@media (min-aspect-ratio: ~"16/9") {
-   .video-background-media {
-      height: 300%;
-      top: -100%;
-   }
-}
-
-@media (max-aspect-ratio: ~"16/9") {
-   .video-background-media {
-      width: 300%;
-      left: -100%;
-   }
-}
-
-@media (max-width: 600px) {
-   .video-background-media {
-      display: none;
+      @media (min-aspect-ratio: ~"16/9") {
+         height: 300%;
+         top: -100%;
+      }
+      @media (max-aspect-ratio: ~"16/9") {
+            width: 300%;
+            left: -100%;
+      }
+      @media (max-width: 600px) {
+         display: none;
+      }
    }
 }
 


### PR DESCRIPTION
Apologies for combining two things, let me know if you would prefer not to have one, the other, or either :)

Using the cameraStream that was implemented, I added support for live streaming tiles on the dashboard without having to go fullscreen to see them.

I also added support for a video background.  For example like this: https://coverr.co/videos/Winter%20Wonderland--65e01801-b64a-4563-b44d-ad38f7b0f481