### PR TITLE
Fix panning triggering during scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,10 @@
 
 <div ng-if="ready" class="page-container"
      hm-pan="onPagePan($event)"
-     hm-recognizer-options="{directions: isMenuOnTheLeft ? 'DIRECTION_VERTICAL' : 'DIRECTION_HORIZONTAL'}"
+     hm-recognizer-options="{
+        enable: isPanEnabled,
+        directions: isMenuOnTheLeft ? 'DIRECTION_VERTICAL' : 'DIRECTION_HORIZONTAL'
+     }"
 >
    <div class="camera-popup"
         ng-if="activeCamera && (entity = getItemEntity(activeCamera))">
@@ -336,6 +339,7 @@
            ng-class="{'-active': isPageActive(page)}"
            ng-if="shouldDrawPage(page) && !isHidden(page)"
            ng-style="pageStyles(page, $index)" class="page"
+           ng-on-scroll="onPageScroll($event)"
            on-scroll on-scroll-model="page">
 
          <!-- legacy -->

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -1743,11 +1743,34 @@ App.controller('Main', ['$scope', '$timeout', '$location', 'Api', function ($sco
 
    $scope.isMenuOnTheLeft = CONFIG.menuPosition === MENU_POSITIONS.LEFT;
 
-   $scope.onPagePan = function (event) {
+   var hasScrolledDuringPan = false;
+
+   $scope.onPageScroll = function () {
+      // Will disable panning when page starts scrolling.
+      // Is reset from isPanEnabled function on starting to pan.
+      hasScrolledDuringPan = true;
+
+      return true;
+   };
+
+   $scope.isPanEnabled = function (recognizer, event) {
       if(hasOpenPopup()) {
          return;
       }
 
+      // Workaround for touch events - cancel recognition on scroll event.
+      if(event && event.pointerType === 'touch') {
+         if(event.isFirst) {
+            hasScrolledDuringPan = false;
+         }
+
+         return !hasScrolledDuringPan;
+      }
+
+      return true;
+   }
+
+   $scope.onPagePan = function (event) {
       if(event.eventType & (Hammer.INPUT_END | Hammer.INPUT_CANCEL)) {
          // Re-enable transitions.
          $scope.pagesContainerStyles.transition = null;


### PR DESCRIPTION
The issue happened only in browsers that didn't support pointer
events. With pointer events browser cancels events when view is
scrolled but with touch events that doesn't happen and we have
to emulate that ourselves.

Should fix issues with panning while scrolling in IOS and Firefox.

Resolves #323

@akloeckner 