### PR TITLE
fix issue, where only one day of history shown

### DIFF
--- a/scripts/models/api.js
+++ b/scripts/models/api.js
@@ -131,15 +131,20 @@ App.provider('Api', function () {
             });
       };
 
-      $Api.prototype.getHistory = function (startDate, filterEntityId) {
+      $Api.prototype.getHistory = function (startDate, filterEntityId, endDate) {
          var request = {
             type: 'GET',
             url: '/api/history/period'
          };
          if (startDate) request.url += '/' + startDate;
+         if (endDate) {
+            request.url += '?end_time=' + endDate;
+         } else {
+            request.url += '?end_time=' + new Date(Date.now()).toISOString();
+         }
          if (filterEntityId) {
             var entityIds = filterEntityId instanceof Array ? filterEntityId.join(',') : filterEntityId;
-            request.url += '?filter_entity_id=' + entityIds;
+            request.url += '&filter_entity_id=' + entityIds;
          }
          return this.rest(request);
       };


### PR DESCRIPTION
end_time was assumed to be one day after after startDate by HA. providing end_time=now() explicitly fixes this.

see https://community.home-assistant.io/t/tileboard-new-dashboard-for-homeassistant/57173/2815