### PR TITLE
A different camera entity id and hls buffersize can now be specified

### DIFF
--- a/TILE_EXAMPLES.md
+++ b/TILE_EXAMPLES.md
@@ -63,6 +63,31 @@ Manually trigger an automation
 }
 ```
 
+#### CAMERA_THUMBNAIL and CAMERA_STREAM
+Shows a camera feed on the tile and opens a fullscreen popup with an RTSP stream when pressed.
+Optionally, the fullscreen camera entity can be different from the thumbnail camera entity, for example to show a hires stream on the fullscreen popup only.
+
+```js
+{
+   position: [0, 0],
+   id: 'camera.front_gate',
+   type: TYPES.CAMERA_THUMBNAIL,
+   bgSize: 'cover',
+   width: 2,
+   state: false,
+   fullscreen: {
+      type: TYPES.CAMERA_STREAM,
+      objFit: 'contain',
+      id: 'camera.front_gate_highres',  // Optional: camera entity to use on fullscreen, defaults to the tile camera entity if omitted
+      bufferLength: 5  // Optional: buffer length in seconds for the HLS buffer, default is 5 seconds
+   },
+   refresh: function () { // can also be a function
+      return 3000 + Math.random() * 1000
+   }
+}
+```
+
+
 #### CLIMATE
 ![CLIMATE](images/tile-screenshots/CLIMATE.png)
 ```js

--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
      }"
 >
    <div class="camera-popup"
-        ng-if="activeCamera && (entity = getItemEntity(activeCamera))">
+        ng-if="activeCamera && (entity = getCameraEntityFullscreen(activeCamera))">
 
       <div class="camera-popup-container">
          <div class="camera-popup-title">
@@ -93,7 +93,7 @@
                  ng-click="openCamera(item)"
                  ng-class="{'-active': activeCamera === item}"
                  ng-repeat="item in getCameraList() track by $index">
-               <span ng-show="entity = getItemEntity(item)">
+               <span ng-show="entity = getCameraEntityFullscreen(item)">
                   <span ng-bind="entityTitle(item, entity)"></span>
                </span>
             </div>

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -150,14 +150,13 @@ App.controller('Main', ['$scope', '$timeout', '$location', 'Api', function ($sco
    };
 
    $scope.getCameraEntityFullscreen = function (item) {
+      var entity_id = item.fullscreen.id;
 
-	  var entity_id = item.fullscreen.id;
+      if(typeof entity_id === "undefined") {
+         entity_id = item.id;
+      }
 
-	  if( typeof entity_id === "undefined" ) {
-		 entity_id = item.id;
-	  }
-
-	  if(typeof entity_id === "object") return entity_id;
+      if(typeof entity_id === "object") return entity_id;
 
       return $scope.states[entity_id];
    };

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -149,6 +149,19 @@ App.controller('Main', ['$scope', '$timeout', '$location', 'Api', function ($sco
       return $scope.states[item.id];
    };
 
+   $scope.getCameraEntityFullscreen = function (item) {
+
+	  var entity_id = item.fullscreen.id;
+
+	  if( typeof entity_id === "undefined" ) {
+		 entity_id = item.id;
+	  }
+
+	  if(typeof entity_id === "object") return entity_id;
+
+      return $scope.states[entity_id];
+   };
+
    $scope.getEntryCameraEntity = function (itemEntry) {
       var item = itemEntry.layout.camera;
 

--- a/scripts/directives.js
+++ b/scripts/directives.js
@@ -190,12 +190,12 @@ App.directive('cameraStream', ['Api', function (Api) {
             el.style.height = '100%';
             el.muted = 'muted';
 
-			var len = ( typeof $scope.item.bufferLength !== "undefined" ) ? $scope.item.bufferLength : 5;
+            var len = (typeof $scope.item.bufferLength !== "undefined") ? $scope.item.bufferLength : 5;
 
-			var config = {
-				maxBufferLength: len,
-				maxMaxBufferLength: len
-			};
+            var config = {
+               maxBufferLength: len,
+               maxMaxBufferLength: len
+            };
 
             var hls = new Hls(config);
             hls.loadSource(url);

--- a/scripts/directives.js
+++ b/scripts/directives.js
@@ -190,7 +190,14 @@ App.directive('cameraStream', ['Api', function (Api) {
             el.style.height = '100%';
             el.muted = 'muted';
 
-            var hls = new Hls();
+			var len = ( typeof $scope.item.bufferLength !== "undefined" ) ? $scope.item.bufferLength : 5;
+
+			var config = {
+				maxBufferLength: len,
+				maxMaxBufferLength: len
+			};
+
+            var hls = new Hls(config);
             hls.loadSource(url);
             hls.attachMedia(el);
             hls.on(Hls.Events.MANIFEST_PARSED, function() {


### PR DESCRIPTION
A separate camera entity id can now be specified for fullscreen cameras, for example to show a high resolution rtsp stream on the popup, while the camera thumbnail tile uses a low resolution and low bandwidth still image sequence. If the id is not specified in the fullscreen object, then the tile item id is used by default, providing backwards compatibility.

The HLS buffer default length was reduced from 30 to 5 seconds to reduce latency, and can optionally be co figured from config.js. If bufferLength is not supplied, 5 seconds are used by default.

Usage:

`
fullscreen: {
   type: TYPES.CAMERA_STREAM,
   ObjFit: 'contain',
   id: 'camera.highres_camera',
   bufferLength: 3
}
`

