### PR TITLE
Use config serverUrl for HLS video stream

### DIFF
--- a/scripts/directives.js
+++ b/scripts/directives.js
@@ -219,8 +219,7 @@ App.directive('cameraStream', ['Api', function (Api) {
                },
                function (res) {
                   if(!res.result) return;
-
-                  appendVideo(res.result.url);
+                  appendVideo(CONFIG.serverUrl + '/'+ res.result.url);
                });
          };
          


### PR DESCRIPTION
When serving TileBoard on a different url then HA API, HLS video streams are not working. 
Added the CONFIG.serverUrl to fix this issue