### PR TITLE
Fix for "Add to Home Screen" feature on iOS 13

### DIFF
--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -4,5 +4,6 @@
     "src": "favicon.png",
     "sizes": "16x16 24x24 32x32 48x48 64x64",
     "type": "image/png"
-  }]
+  }],
+  "display": "fullscreen"
 }


### PR DESCRIPTION
iOS 13 requires not only the `"apple-mobile-web-app-capable"` meta tag but also either one of the entries `"display": "standalone"` or `"display": "fullscreen"` in the manifest file. Otherwise the "Add to Home Screen" function only creates a link to TileBoard which opens the interface in Safari. With the manifest "display" entry it behaves more like a "progressive web app", hiding the browser UI and address bar.


https://developer.mozilla.org/en-US/docs/Web/Manifest/display