### PR TITLE
Improve category/linear decision on history data

### DIFF
--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -1592,7 +1592,7 @@ App.controller('Main', ['$scope', '$timeout', '$location', 'Api', function ($sco
                var seriesUnit = firstStateInfo.attributes.unit_of_measurement;
 
                // Either categorial or continuous data.
-               var yAxisType = Number.isNaN(parseFloat(dataset[0].y)) ? 'category' : 'linear';
+               var yAxisType = Number.isNaN(parseFloat(dataset[dataset.length - 1].y)) ? 'category' : 'linear';
                var yAxisId = yAxisType + (seriesUnit ? '-' + seriesUnit : '');
                var createYAxis = false;
 


### PR DESCRIPTION
As it seems, the first data point can likely be `undefined`.
As long as this point is in the history scope, the data is handled as categorial.
Using the last data point should improve this.
It will return linear at least statistically more often for linear data..