### PR TITLE
changed parameters to support more light types

### DIFF
--- a/index.html
+++ b/index.html
@@ -734,21 +734,21 @@
          <div ng-if="item.controlsEnabled" class="item-entity-sliders"
               ng-click="preventClick($event)">
             <div ng-repeat="slider in item.sliders track by $index"
-                 ng-if="(_c = getLightSliderConf(slider, entity))"
+                 ng-if="(_c_ = getLightSliderConf(slider, entity))"
                  class="item-slider-container">
 
                <div class="item-slider-title" ng-if="slider.title">
                   <span ng-bind="slider.title"></span>:
-                  <span ng-bind="getLightSliderValue(slider, _c)"></span>
+                  <span ng-bind="getLightSliderValue(slider, _c_)"></span>
                </div>
 
                <div class="item-slider">
-                  <input type="range" ng-model="_c.value" value="{{ _c.value }}"
+                  <input type="range" ng-model="_c_.value" value="{{ _c_.value }}"
                          ng-on-touchstart="$event.stopPropagation()"
                          ng-on-touchmove="$event.stopPropagation()"
                          ng-on-pointerdown="$event.stopPropagation()"
-                         ng-change="lightSliderChanged(slider, item, entity, _c)"
-                         step="{{ _c.step }}" min="{{ _c.min }}" max="{{ _c.max }}">
+						 step="{{ _c_.step }}" min="{{ _c_.min }}" max="{{ _c_.max }}"
+                         ng-change="lightSliderChanged(slider, item, entity, _c_)">
                </div>
             </div>
           

--- a/index.html
+++ b/index.html
@@ -747,7 +747,7 @@
                          ng-on-touchstart="$event.stopPropagation()"
                          ng-on-touchmove="$event.stopPropagation()"
                          ng-on-pointerdown="$event.stopPropagation()"
-						 step="{{ _c_.step }}" min="{{ _c_.min }}" max="{{ _c_.max }}"
+						 step="{{ slider.step }}" min="{{ slider.min }}" max="{{ slider.max }}"
                          ng-change="lightSliderChanged(slider, item, entity, _c_)">
                </div>
             </div>

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -1014,6 +1014,7 @@ App.controller('Main', ['$scope', '$timeout', '$location', 'Api', function ($sco
    };
 
    $scope.toggleSwitch = function (item, entity, callback) {
+	  if(item.controlsEnabled) return;
       var domain = "homeassistant";
       var group = item.id.split('.')[0];
 

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -869,7 +869,7 @@ App.controller('Main', ['$scope', '$timeout', '$location', 'Api', function ($sco
 
             $timeout(function () {
                item._controlsInited = true;
-            }, 50);
+            }, 500);
          }
       }
    };


### PR DESCRIPTION
### index.html
thorough testing yesterday to why my light (with a max value of 254) did not appear at the correct value when long pressing.

apparently because `step, min and max` are being read AFTER `ng-change` on its first init the `max` is unknown and will be set to html's default of `100`.

setting `step, min and max` above `ng-change` with reading the value's for these directly from `slider` instead of the model fixed the issue.

changed `getLightSliderConf` variable to `_c_` instead of `_c` to better represent the code in `main.js`

### main.js
increased timer for opening the `long press` menu to give it more stability/accuracy.
added the check for `controlsEnabled` to make sure that `long press` does not do another `single press` after letting go.