### PR TITLE
Fix clicking menu on the left through the header

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -31,7 +31,7 @@ var CONFIG = {
 
    header: { // https://github.com/resoai/TileBoard/wiki/Header-configuration
       styles: {
-         padding: '30px 130px 0',
+         margin: '30px 130px 0',
          fontSize: '28px'
       },
       right: [],

--- a/styles/main.css
+++ b/styles/main.css
@@ -241,6 +241,10 @@ body {
   top: 0;
   font-size: 20px;
   color: #fff;
+  pointer-events: none;
+}
+.header-content {
+  pointer-events: all;
 }
 .header-content:after {
   content: " ";

--- a/styles/main.less
+++ b/styles/main.less
@@ -242,8 +242,10 @@ body {
    top: 0;
    font-size: 20px;
    color: #fff;
+   pointer-events: none;
 
    &-content {
+      pointer-events: all;
 
       &:after {
          content: " ";


### PR DESCRIPTION
Something we could do to address #385. At least for browsers that support pointer-events.

People would have to update their configs for this to be effective.

Not sure what implications changing from padding to margin can have on the header but seems to work in my layout at least.

Resolves #385