### PR TITLE
Fix ghost clicks on popup

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -226,6 +226,8 @@ var MINIMAL_CHART_OPTIONS = {
    },
 };
 
+var GHOST_CLICK_TIMEOUT = 500;
+
 window.onerror = function (error, file, line, char) {
    var text = [
       error,

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -857,7 +857,7 @@ App.controller('Main', ['$scope', '$timeout', '$location', 'Api', function ($sco
 
             $timeout(function () {
                item._controlsInited = true;
-            }, 50);
+            }, GHOST_CLICK_TIMEOUT);
          }
       }
    };
@@ -865,6 +865,8 @@ App.controller('Main', ['$scope', '$timeout', '$location', 'Api', function ($sco
    $scope.closeLightSliders = function ($event, item, entity) {
       $event.preventDefault();
       $event.stopPropagation();
+
+      if(!item._controlsInited) return;
 
       item.controlsEnabled = false;
       item._controlsInited = false;
@@ -1540,10 +1542,9 @@ App.controller('Main', ['$scope', '$timeout', '$location', 'Api', function ($sco
         entity: entity,
         layout: layout || item.popup
       };
-      // prevent popup closing from ghost clicks
       $timeout(function () {
          $scope.activePopup.inited = true;
-      }, 500); // trades responsiveness vs prevention
+      }, GHOST_CLICK_TIMEOUT);
    };
 
    $scope.closePopup = function () {

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -1540,9 +1540,14 @@ App.controller('Main', ['$scope', '$timeout', '$location', 'Api', function ($sco
         entity: entity,
         layout: layout || item.popup
       };
+      // prevent popup closing from ghost clicks
+      $timeout(function () {
+         $scope.activePopup.inited = true;
+      }, 500); // trades responsiveness vs prevention
    };
 
    $scope.closePopup = function () {
+      if (!$scope.activePopup.inited) return;
       $scope.activePopup = null;
    };
 


### PR DESCRIPTION
Fixes #405 
Closes #407 

This is a different fix for issue #405 . It uses the same mechanism already in place for light controls. It puts the mechanism also to the light controls back button.

There is now a variable to set the timeout, because 50ms were not sufficient for my apparently slow device. The user should thus be able to adopt to their devices' capabilities. I found 500ms sufficient to cancel most ghosts. I believe it will not harm responsiveness too much. After all, humans will need roughly 1000ms to react to anything anyways...