### PR TITLE
clean up popup-related styles and fix size issue

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -1079,6 +1079,7 @@ camera_stream div {
   box-sizing: border-box;
   background: rgba(45, 49, 53, 0.78);
 }
+<<<<<<< Updated upstream
 .camera-popup-container,
 .door-entry-popup-container,
 .iframe-popup-container,
@@ -1091,6 +1092,8 @@ camera_stream div {
   position: relative;
   margin: auto;
 }
+=======
+>>>>>>> Stashed changes
 .camera-popup-title,
 .door-entry-popup-title,
 .iframe-popup-title,
@@ -1125,6 +1128,16 @@ camera_stream div {
 .popup-close:active {
   color: rgba(255, 255, 255, 0.8);
   background: rgba(0, 0, 0, 0.3);
+}
+.camera-popup-container,
+.door-entry-popup-container {
+  background: #111;
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+  position: relative;
+  margin: auto;
 }
 .camera-popup--list,
 .door-entry-popup--list,
@@ -1207,7 +1220,12 @@ camera_stream div {
   justify-content: center;
   align-items: center;
 }
-.popup .popup-container {
+.popup-container {
+  background: #111;
+  overflow: hidden;
+  white-space: nowrap;
+  position: relative;
+  margin: auto;
   /* auto-size container */
   width: auto;
   height: auto;

--- a/styles/main.css
+++ b/styles/main.css
@@ -1212,7 +1212,6 @@ camera_stream div {
   align-items: center;
 }
 .popup-container {
-  overflow: hidden;
   width: auto;
   height: auto;
   max-width: 100%;

--- a/styles/main.css
+++ b/styles/main.css
@@ -1207,7 +1207,7 @@ camera_stream div {
   justify-content: center;
   align-items: center;
 }
-.popup-container {
+.popup .popup-container {
   /* auto-size container */
   width: auto;
   height: auto;

--- a/styles/main.css
+++ b/styles/main.css
@@ -1079,21 +1079,6 @@ camera_stream div {
   box-sizing: border-box;
   background: rgba(45, 49, 53, 0.78);
 }
-<<<<<<< Updated upstream
-.camera-popup-container,
-.door-entry-popup-container,
-.iframe-popup-container,
-.popup-container {
-  background: #111;
-  height: 100%;
-  width: 100%;
-  overflow: hidden;
-  white-space: nowrap;
-  position: relative;
-  margin: auto;
-}
-=======
->>>>>>> Stashed changes
 .camera-popup-title,
 .door-entry-popup-title,
 .iframe-popup-title,
@@ -1130,7 +1115,8 @@ camera_stream div {
   background: rgba(0, 0, 0, 0.3);
 }
 .camera-popup-container,
-.door-entry-popup-container {
+.door-entry-popup-container,
+.iframe-popup-container {
   background: #111;
   height: 100%;
   width: 100%;

--- a/styles/main.css
+++ b/styles/main.css
@@ -1079,6 +1079,16 @@ camera_stream div {
   box-sizing: border-box;
   background: rgba(45, 49, 53, 0.78);
 }
+.camera-popup-container,
+.door-entry-popup-container,
+.iframe-popup-container,
+.popup-container {
+  background: #111;
+  overflow: hidden;
+  white-space: nowrap;
+  position: relative;
+  margin: auto;
+}
 .camera-popup-title,
 .door-entry-popup-title,
 .iframe-popup-title,
@@ -1117,13 +1127,8 @@ camera_stream div {
 .camera-popup-container,
 .door-entry-popup-container,
 .iframe-popup-container {
-  background: #111;
   height: 100%;
   width: 100%;
-  overflow: hidden;
-  white-space: nowrap;
-  position: relative;
-  margin: auto;
 }
 .camera-popup--list,
 .door-entry-popup--list,
@@ -1207,12 +1212,7 @@ camera_stream div {
   align-items: center;
 }
 .popup-container {
-  background: #111;
   overflow: hidden;
-  white-space: nowrap;
-  position: relative;
-  margin: auto;
-  /* auto-size container */
   width: auto;
   height: auto;
   max-width: 100%;

--- a/styles/main.less
+++ b/styles/main.less
@@ -1217,16 +1217,6 @@ camera_stream {
    box-sizing: border-box;
    background: rgba(45, 49, 53, 0.78);
 
-   &-container {
-      background: @popupBackground;
-      height: 100%;
-      width: 100%;
-      overflow: hidden;
-      white-space: nowrap;
-      position: relative;
-      margin: auto;
-   }
-
    &-title {
       background: @popupTitleBackground;
       color: rgba(255,255,255,.6);
@@ -1258,8 +1248,22 @@ camera_stream {
 }
 
 .camera-popup,
+<<<<<<< Updated upstream
 .door-entry-popup,
 .iframe-popup {
+=======
+.door-entry-popup {
+   &-container {
+      background: @popupBackground;
+      height: 100%;
+      width: 100%;
+      overflow: hidden;
+      white-space: nowrap;
+      position: relative;
+      margin: auto;
+   }
+
+>>>>>>> Stashed changes
    &--list {
       width: 200px;
       display: inline-block;
@@ -1345,10 +1349,14 @@ camera_stream {
    justify-content: center;
    align-items: center;
 
-   .popup-container { 
+   &-container {
+      background: @popupBackground;
+      overflow: hidden;
+      white-space: nowrap;
+      position: relative;
+      margin: auto;
+
       /* auto-size container */
-      // Not simply &-container, in order to make this more specific
-      // and override the less specific height and width settings above
       width: auto;
       height: auto;
       max-width: 100%;

--- a/styles/main.less
+++ b/styles/main.less
@@ -1248,11 +1248,8 @@ camera_stream {
 }
 
 .camera-popup,
-<<<<<<< Updated upstream
 .door-entry-popup,
 .iframe-popup {
-=======
-.door-entry-popup {
    &-container {
       background: @popupBackground;
       height: 100%;
@@ -1263,7 +1260,6 @@ camera_stream {
       margin: auto;
    }
 
->>>>>>> Stashed changes
    &--list {
       width: 200px;
       display: inline-block;

--- a/styles/main.less
+++ b/styles/main.less
@@ -1345,8 +1345,10 @@ camera_stream {
    justify-content: center;
    align-items: center;
 
-   &-container {
+   .popup-container { 
       /* auto-size container */
+      // Not simply &-container, in order to make this more specific
+      // and override the less specific height and width settings above
       width: auto;
       height: auto;
       max-width: 100%;

--- a/styles/main.less
+++ b/styles/main.less
@@ -1344,7 +1344,6 @@ camera_stream {
    align-items: center;
 
    &-container {
-      overflow: hidden;
       width: auto;
       height: auto;
       max-width: 100%;

--- a/styles/main.less
+++ b/styles/main.less
@@ -1217,6 +1217,14 @@ camera_stream {
    box-sizing: border-box;
    background: rgba(45, 49, 53, 0.78);
 
+   &-container {
+      background: @popupBackground;
+      overflow: hidden;
+      white-space: nowrap;
+      position: relative;
+      margin: auto;
+   }
+
    &-title {
       background: @popupTitleBackground;
       color: rgba(255,255,255,.6);
@@ -1251,13 +1259,8 @@ camera_stream {
 .door-entry-popup,
 .iframe-popup {
    &-container {
-      background: @popupBackground;
       height: 100%;
       width: 100%;
-      overflow: hidden;
-      white-space: nowrap;
-      position: relative;
-      margin: auto;
    }
 
    &--list {
@@ -1314,10 +1317,6 @@ camera_stream {
 }
 
 .door-entry-popup {
-
-   &-container {
-   }
-
    &--tiles {
       position: absolute;
       left: 15px;
@@ -1338,7 +1337,6 @@ camera_stream {
    }
 }
 
-
 .popup {
    /* center popup on screen */
    display: flex;
@@ -1346,13 +1344,7 @@ camera_stream {
    align-items: center;
 
    &-container {
-      background: @popupBackground;
       overflow: hidden;
-      white-space: nowrap;
-      position: relative;
-      margin: auto;
-
-      /* auto-size container */
       width: auto;
       height: auto;
       max-width: 100%;


### PR DESCRIPTION
My old iPad would be confused by the two definitions of popup-container and it would always display the history popup fullsize. Now it's less cluttered and unambiguous.