### PR TITLE
Simplify HTML by combining all "simple" tiles into one template

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Tile Object. [Click here for some real-life examples](TILE_EXAMPLES.md)
    * You can use any of the material design icons from https://materialdesignicons.com/
    * as long as they have been published in the [latest npm package](https://github.com/templarian/materialdesign-svg).
    */
-  icon: 'mdi-phone'
+  icon: 'mdi-phone',
   /* customHtml: Replace the icon by a custom HTML content
    * If you define this option, simple tiles will not show the icon. They will show your custom HTML instead.
    * You can use an anonymous function here, or a string that will be interpreted as a template

--- a/README.md
+++ b/README.md
@@ -248,6 +248,12 @@ Tile Object. [Click here for some real-life examples](TILE_EXAMPLES.md)
    * as long as they have been published in the [latest npm package](https://github.com/templarian/materialdesign-svg).
    */
   icon: 'mdi-phone'
+  /* customHtml: Replace the icon by a custom HTML content
+   * If you define this option, simple tiles will not show the icon. They will show your custom HTML instead.
+   * You can use an anonymous function here, or a string that will be interpreted as a template
+   */
+  customHtml: function (item, entity) {return '<b>' + entity.state + '</b>';},
+  customHtml: '<b>&group.lights.state</b>',
   /* bg: Link to a background image for the tile
    * @ and & prefixes are explained below
    */

--- a/index.html
+++ b/index.html
@@ -521,6 +521,31 @@
          </div>
       </div>
 
+      <div ng-if="[TYPES.ALARM,
+                   TYPES.AUTOMATION,
+                   TYPES.COVER_TOGGLE,
+                   TYPES.CUSTOM,
+                   TYPES.DOOR_ENTRY,
+                   TYPES.INPUT_BOOLEAN,
+                   TYPES.LOCK,
+                   TYPES.POPUP,
+                   TYPES.POPUP_IFRAME,
+                   TYPES.SCENE,
+                   TYPES.SCRIPT,
+                   TYPES.SENSOR_ICON,
+                   TYPES.SWITCH,
+                   TYPES.VACUUM,
+                   ].includes(item.type)"
+           class="item-entity-container">
+         <div ng-if="item.customHtml"
+              ng-bind-html="itemCustomHtml(item, entity)"></div>
+
+         <div ng-if="!item.customHtml" class="item-entity">
+            <span class="item-entity--icon mdi"
+                  ng-class="entityIcon(item, entity)"></span>
+         </div>
+      </div>
+
       <div ng-if="item.type === TYPES.DEVICE_TRACKER"
            class="item-entity-container -below">
 
@@ -551,24 +576,6 @@
          </div>
       </div>
 
-      <div ng-if="item.type === TYPES.SWITCH"
-           class="item-entity-container">
-
-         <div class="item-entity">
-            <span class="item-entity--icon mdi"
-                  ng-class="entityIcon(item, entity)"></span>
-         </div>
-      </div>
-
-      <div ng-if="item.type === TYPES.LOCK"
-           class="item-entity-container">
-
-         <div class="item-entity">
-            <span class="item-entity--icon mdi"
-                  ng-class="entityIcon(item, entity)"></span>
-         </div>
-      </div>
-
       <div ng-if="item.type === TYPES.COVER"
            class="item-entity-container">
 
@@ -589,15 +596,6 @@
                  ng-click="sendCover('close_cover', item, entity)">
                <i class="mdi mdi-arrow-down"></i>
             </div>
-         </div>
-      </div>
-
-      <div ng-if="item.type === TYPES.COVER_TOGGLE"
-           class="item-entity-container">
-
-         <div class="item-entity">
-            <span class="item-entity--icon mdi"
-                  ng-class="entityIcon(item, entity)"></span>
          </div>
       </div>
 
@@ -625,83 +623,6 @@
                  ng-click="setFanSpeed($event, item, entity, option)">
                <span ng-bind="option"></span>
             </div>
-         </div>
-      </div>
-
-      <div ng-if="item.type === TYPES.CUSTOM"
-           class="item-entity-container">
-
-         <div ng-if="item.customHtml"
-              ng-bind-html="itemCustomHtml(item, entity)"></div>
-
-         <div ng-if="!item.customHtml" class="item-entity">
-            <span class="item-entity--icon mdi"
-                  ng-class="entityIcon(item, entity)"></span>
-         </div>
-      </div>
-
-      <div ng-if="item.type === TYPES.POPUP_IFRAME"
-           class="item-entity-container">
-
-         <div ng-if="item.customHtml"
-              ng-bind-html="itemCustomHtml(item, entity)"></div>
-
-         <div ng-if="!item.customHtml" class="item-entity">
-            <span class="item-entity--icon mdi"
-                  ng-class="entityIcon(item, entity)"></span>
-         </div>
-      </div>
-
-      <div ng-if="item.type === TYPES.POPUP"
-           class="item-entity-container">
-
-         <div class="item-entity">
-            <span class="item-entity--icon mdi"
-                  ng-class="entityIcon(item, entity)"></span>
-         </div>
-      </div>
-
-      <div ng-if="item.type === TYPES.SCRIPT"
-           class="item-entity-container">
-
-         <div class="item-entity">
-            <span class="item-entity--icon mdi"
-                  ng-class="entityIcon(item, entity)"></span>
-         </div>
-      </div>
-
-      <div ng-if="item.type === TYPES.AUTOMATION"
-           class="item-entity-container">
-
-         <div class="item-entity">
-            <span class="item-entity--icon mdi"
-                  ng-class="entityIcon(item, entity)"></span>
-         </div>
-      </div>
-
-      <div ng-if="item.type === TYPES.VACUUM"
-           class="item-entity-container">
-
-         <div class="item-entity">
-            <span class="item-entity--icon mdi"
-                  ng-class="entityIcon(item, entity)"></span>
-         </div>
-      </div>
-
-      <div ng-if="item.type === TYPES.SENSOR_ICON"
-           class="item-entity-container">
-         <div class="item-entity">
-            <span class="item-entity--icon mdi"
-                  ng-class="entityIcon(item, entity)"></span>
-         </div>
-      </div>
-
-      <div ng-if="item.type === TYPES.INPUT_BOOLEAN"
-           class="item-entity-container">
-
-         <div class="item-entity">
-            <span class="item-entity--icon mdi"
-                  ng-class="entityIcon(item, entity)"></span>
          </div>
       </div>
 
@@ -768,6 +689,7 @@
             </div>
          </div>
       </div>
+
       <div ng-if="item.type === TYPES.DIMMER_SWITCH"
            class="item-entity-container">
 
@@ -826,7 +748,6 @@
          </div>
       </div>
 
-
       <div ng-if="item.type === TYPES.INPUT_SELECT"
            class="item-entity-container">
          <div ng-if="selectOpened(item)" class="item-select"
@@ -860,7 +781,6 @@
          </div>
       </div>
 
-
       <div ng-if="item.type === TYPES.CAMERA"
            class="item-entity-container -below">
          <div class="item-camera">
@@ -882,15 +802,6 @@
          <div class="item-camera">
             <camera-stream item="item" entity="entity"
                            freezed="!isPageActive(page) || activeCamera || screensaverShown"></camera-stream>
-         </div>
-      </div>
-
-      <div ng-if="item.type === TYPES.SCENE"
-           class="item-entity-container">
-
-         <div class="item-entity">
-            <span class="item-entity--icon mdi"
-                  ng-class="entityIcon(item, entity)"></span>
          </div>
       </div>
 
@@ -922,27 +833,6 @@
                     iframe-tile="item" frameborder="0"></iframe>
          </div>
       </div>
-
-
-      <div ng-if="item.type === TYPES.DOOR_ENTRY"
-           class="item-entity-container">
-
-         <div class="item-entity">
-            <span class="item-entity--icon mdi"
-                  ng-class="entityIcon(item, entity)"></span>
-         </div>
-      </div>
-
-
-      <div ng-if="item.type === TYPES.ALARM"
-           class="item-entity-container">
-
-         <div class="item-entity">
-            <span class="item-entity--icon mdi"
-                  ng-class="entityIcon(item, entity)"></span>
-         </div>
-      </div>
-
 
       <div ng-if="item.type === TYPES.WEATHER"
            class="item-entity-container">
@@ -1105,7 +995,6 @@
             </div>
          </div>
       </div>
-
 
       <div ng-if="item.type === TYPES.MEDIA_PLAYER"
            class="item-entity-container">

--- a/index.html
+++ b/index.html
@@ -538,7 +538,7 @@
                    ].includes(item.type)"
            class="item-entity-container">
          <div ng-if="item.customHtml"
-              ng-bind-html="itemCustomHtml(item, entity)"></div>
+              ng-bind-html="itemField('customHtml', item, entity)"></div>
 
          <div ng-if="!item.customHtml" class="item-entity">
             <span class="item-entity--icon mdi"

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -521,14 +521,6 @@ App.controller('Main', ['$scope', '$timeout', '$location', 'Api', function ($sco
       return getItemFieldValue(field, item, entity);
    };
 
-   $scope.itemCustomHtml = function (item, entity) {
-      if (typeof item.customHtml === 'function') {
-         return callFunction(item.customHtml, [item, entity]);
-      }
-
-      return item.customHtml;
-   };
-
    $scope.entityUnit = function (item, entity) {
       if(!('unit' in item)) {
          return entity.attributes ? entity.attributes.unit_of_measurement : null;


### PR DESCRIPTION
When setting up popups, I came across the fact that many many tiles actually had the very same content. I fixed that up into one tile template. Basically not much changes, but the code gets much smaller and simpler. 

In this course, I also removed one superfluous function, because the existent and more generic function `itemField` could be used instead.

Things that do change:
* all simple tiles have `customHtml` option now.
* the customHtml option additionally accepts templates now.