### PR TITLE
Replace horrible hack for disabling scrollbar with CSS

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -221,7 +221,15 @@ body {
   font-size: 0;
 }
 .-hide-scrollbar .page {
-  height: 102%;
+  scrollbar-width: none;
+  /* Firefox */
+  -ms-overflow-style: none;
+  /* Internet Explorer 10+ */
+}
+.-hide-scrollbar .page::-webkit-scrollbar {
+  /* WebKit */
+  width: 0;
+  height: 0;
 }
 .page-head {
   position: absolute;

--- a/styles/main.less
+++ b/styles/main.less
@@ -211,7 +211,13 @@ body {
 
 .-hide-scrollbar {
    .page {
-      height: 102%; // hack but imo better than calc()
+      scrollbar-width: none; /* Firefox */
+      -ms-overflow-style: none;  /* Internet Explorer 10+ */
+
+      &::-webkit-scrollbar { /* WebKit */
+         width: 0;
+         height: 0;
+      }
    }
 }
 
@@ -224,10 +230,6 @@ body {
    top: 0;
 
    color: #fff;
-
-   &-content {
-
-   }
 
    &--left {
       float: left;


### PR DESCRIPTION
The CSS solution, while probably only compatible with newer browsers,
doesn't introduce a horrible issue where switching pages makes them
have an extra offset added on top.

Resolves #415