### PR TITLE
fix: cache in item instead of entity

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,6 +1,6 @@
 env:
   browser: true
-  es2017: true
+  es2020: true
   node: true
 parserOptions:
   sourceType: module

--- a/index.html.ejs
+++ b/index.html.ejs
@@ -562,7 +562,7 @@
          <div ng-if="item.controlsEnabled" class="item-entity-sliders"
               ng-click="preventClick($event)">
             <div ng-repeat="slider in item.sliders track by $index"
-                 ng-if="(_c = getLightSliderConf(slider, entity))"
+                 ng-if="(_c = getLightSliderConf(item, entity, slider))"
                  class="item-slider-container">
 
                <div class="item-slider-title" ng-if="slider.title">

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -449,35 +449,22 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
       return item.styles;
    };
 
-   $scope.itemBgStyles = function (item, entity) {
-      const obj = entity.attributes || entity;
-
-      if (!obj.bgStyles) {
-         let bg;
-         const styles = {};
-
-         if ('bgOpacity' in item) {
-            styles.opacity = parseFieldValue(item.bgOpacity, item, entity);
-         }
-
-         if (item.bg) {
-            bg = parseFieldValue(item.bg, item, entity);
-
-            if (bg) {
-               styles.backgroundImage = 'url(' + bg + ')';
-            }
-         } else if (item.bgSuffix) {
-            bg = parseFieldValue(item.bgSuffix, item, entity);
-
-            if (bg) {
-               styles.backgroundImage = 'url("' + toAbsoluteServerURL(bg) + '")';
-            }
-         }
-
-         obj.bgStyles = styles;
+   function cacheInItem (item, key, data) {
+      if (!item[key]) {
+         item[key] = typeof data === 'function' ? data() : data;
       }
+      return item[key];
+   }
 
-      return obj.bgStyles;
+   $scope.itemBgStyles = function (item, entity) {
+      const bg = getItemFieldValue('bg', item, entity);
+      const bgSuffix = getItemFieldValue('bgSuffix', item, entity);
+
+      return cacheInItem(item, 'bgStyles', {
+         opacity: getItemFieldValue('bgOpacity', item, entity) || null,
+         backgroundImage: bg ? 'url(' + bg + ')'
+            : bgSuffix ? 'url(' + toAbsoluteServerURL(bgSuffix) + ')' : null,
+      });
    };
 
    $scope.itemClasses = function (item) {
@@ -825,64 +812,41 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
       return page.header;
    };
 
-   $scope.getSliderConf = function (item, entity) {
-      const key = '_c';
-
-      if (!entity.attributes) {
-         entity.attributes = {};
-      }
-      if (entity.attributes[key]) {
-         return entity.attributes[key];
-      }
-
-      const def = item.slider || {};
-      const attrs = entity.attributes || {};
-      const value = +attrs[def.field] || 0;
-
-      entity.attributes[key] = {
+   function initSliderConf (item, entity, key, def, attrs, value, default_request) {
+      return cacheInItem(item, key, {
          max: attrs.max || def.max || 100,
          min: attrs.min || def.min || 0,
          step: attrs.step || def.step || 1,
          value: value || +entity.state || def.value || 0,
-         request: def.request || {
-            domain: 'input_number',
-            service: 'set_value',
-            field: 'value',
-         },
+         request: def.request || default_request,
+      });
+   }
+
+   $scope.getSliderConf = function (item, entity) {
+      const def = item.slider || {};
+      const attrs = entity.attributes || {};
+      const value = +attrs[def.field] || 0;
+      const default_request = {
+         domain: 'input_number',
+         service: 'set_value',
+         field: 'value',
       };
 
       $timeout(function () {
          item._sliderInited = true;
       }, 50);
 
-      return entity.attributes[key];
+      return initSliderConf(item, entity, '_c_inputNumberSlider', def, attrs, value, default_request);
    };
 
    $scope.getLightSliderConf = function (slider, entity) {
-      const key = '_c_' + slider.field;
-
-      if (!entity.attributes) {
-         entity.attributes = {};
-      }
-      if (entity.attributes[key]) {
-         return entity.attributes[key];
-      }
-
-
       const def = slider || {};
       const attrs = entity.attributes;
       const value = +attrs[def.field] || 0;
-
-      entity.attributes[key] = {
-         max: def.max || attrs.max || 100,
-         min: def.min || attrs.min || 0,
-         step: def.step || attrs.step || 1,
-         value: value || def.min || attrs.min || 0,
-         request: def.request || {
-            domain: 'input_number',
-            service: 'set_value',
-            field: 'value',
-         },
+      const default_request = {
+         domain: 'input_number',
+         service: 'set_value',
+         field: 'value',
       };
 
       $timeout(function () {
@@ -894,37 +858,24 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
          entity.attributes._sliderInited = true;
       }, 0);
 
-      return entity.attributes[key];
+      return initSliderConf(slider, entity, '_c_lightSlider', def, attrs, value, default_request);
    };
 
    $scope.getVolumeConf = function (item, entity) {
-      if (!entity.attributes) {
-         entity.attributes = {};
-      }
-      if (entity.attributes._c) {
-         return entity.attributes._c;
-      }
-
       const def = { max: 100, min: 0, step: 2 };
       const attrs = entity.attributes;
       const value = attrs.volume_level * 100 || 0;
+      const default_request = {};
 
       if (!('volume_level' in attrs)) {
          return false;
       }
 
-      entity.attributes._c = {
-         max: attrs.max || def.max || 100,
-         min: attrs.min || def.min || 0,
-         step: attrs.step || def.step || 1,
-         value: value || 0,
-      };
-
       $timeout(function () {
          entity.attributes._sliderInited = true;
       }, 50);
 
-      return entity.attributes._c;
+      return initSliderConf(item, entity, '_c_volumeSlider', def, attrs, value, default_request);
    };
 
    $scope.getLightSliderValue = function (slider, conf) {

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -449,13 +449,6 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
       return item.styles;
    };
 
-   function cacheInItem (item, key, data) {
-      if (!item[key]) {
-         item[key] = typeof data === 'function' ? data() : data;
-      }
-      return item[key];
-   }
-
    $scope.itemBgStyles = function (item, entity) {
       const bg = getItemFieldValue('bg', item, entity);
       const bgSuffix = getItemFieldValue('bgSuffix', item, entity);

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -813,7 +813,7 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
 
       return cacheInItem(item, key, function () {
          const attrs = entity.attributes || {};
-         const value = +attrs[def.field] || 0;
+         const value = +attrs[def.field] ?? 0;
          const default_request = {
             domain: 'input_number',
             service: 'set_value',
@@ -825,10 +825,10 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
          }, 50);
 
          return {
-            max: attrs.max || def.max || 100,
-            min: attrs.min || def.min || 0,
-            step: attrs.step || def.step || 1,
-            value: value || +entity.state || def.value || 0,
+            max: attrs.max ?? def.max ?? 100,
+            min: attrs.min ?? def.min ?? 0,
+            step: (attrs.step ?? def.step) || 1,
+            value: value ?? +entity.state ?? def.value ?? 0,
             request: def.request || default_request,
          };
       });

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -839,7 +839,7 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
       return initSliderConf(item, entity, '_c_inputNumberSlider', def, attrs, value, default_request);
    };
 
-   $scope.getLightSliderConf = function (slider, entity) {
+   $scope.getLightSliderConf = function (item, entity, slider) {
       const def = slider || {};
       const attrs = entity.attributes;
       const value = +attrs[def.field] || 0;
@@ -858,7 +858,7 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
          entity.attributes._sliderInited = true;
       }, 0);
 
-      return initSliderConf(slider, entity, '_c_lightSlider', def, attrs, value, default_request);
+      return initSliderConf(item, entity, '_c_lightSlider_' + slider.field, def, attrs, value, default_request);
    };
 
    $scope.getVolumeConf = function (item, entity) {

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -805,8 +805,18 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
       return page.header;
    };
 
-   function initSliderConf (item, entity, key, def, attrs, value, default_request) {
+   function initSliderConf (item, entity, def, value) {
+      const key = '_c_slider_' + def.field;
+
       return cacheInItem(item, key, function () {
+         const attrs = entity.attributes || {};
+         const value = +attrs[def.field] || 0;
+         const default_request = {
+            domain: 'input_number',
+            service: 'set_value',
+            field: 'value',
+         };
+
          $timeout(function () {
             item._sliderInited = true;
          }, 50);
@@ -823,44 +833,27 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
 
    $scope.getSliderConf = function (item, entity) {
       const def = item.slider || {};
-      const attrs = entity.attributes || {};
-      const value = +attrs[def.field] || 0;
-      const default_request = {
-         domain: 'input_number',
-         service: 'set_value',
-         field: 'value',
-      };
-      return initSliderConf(item, entity, '_c_inputNumberSlider', def, attrs, value, default_request);
+      return initSliderConf(item, entity, def);
    };
 
    $scope.getLightSliderConf = function (item, entity, slider) {
       const def = slider || {};
-      const attrs = entity.attributes;
-      const value = +attrs[def.field] || 0;
-      const default_request = {
-         domain: 'input_number',
-         service: 'set_value',
-         field: 'value',
-      };
 
       $timeout(function () {
          slider._sliderInited = true;
       }, 100);
 
-      return initSliderConf(item, entity, '_c_lightSlider_' + slider.field, def, attrs, value, default_request);
+      return initSliderConf(item, entity, def);
    };
 
    $scope.getVolumeConf = function (item, entity) {
-      const def = { max: 100, min: 0, step: 2 };
-      const attrs = entity.attributes;
-      const value = attrs.volume_level * 100 || 0;
-      const default_request = {};
+      const def = { max: 1.0, min: 0.0, step: 0.02, field: 'volume_level' };
 
-      if (!('volume_level' in attrs)) {
+      if (!('volume_level' in entity.attributes)) {
          return false;
       }
 
-      return initSliderConf(item, entity, '_c_volumeSlider', def, attrs, value, default_request);
+      return initSliderConf(item, entity, def);
    };
 
    $scope.getLightSliderValue = function (slider, conf) {
@@ -1010,7 +1003,7 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
       }
 
       const value = {
-         value: conf.value / 100,
+         value: conf.value,
          request: {
             domain: 'media_player',
             service: 'volume_set',

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -450,13 +450,16 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
    };
 
    $scope.itemBgStyles = function (item, entity) {
-      const bg = getItemFieldValue('bg', item, entity);
-      const bgSuffix = getItemFieldValue('bgSuffix', item, entity);
+      return cacheInItem(item, 'bgStyles', () => {
+         const bg = getItemFieldValue('bg', item, entity);
+         const bgSuffix = getItemFieldValue('bgSuffix', item, entity);
+         const opacity = getItemFieldValue('bgOpacity', item, entity);
 
-      return cacheInItem(item, 'bgStyles', {
-         opacity: getItemFieldValue('bgOpacity', item, entity) || null,
-         backgroundImage: bg ? 'url(' + bg + ')'
-            : bgSuffix ? 'url(' + toAbsoluteServerURL(bgSuffix) + ')' : null,
+         return {
+            opacity: opacity || null,
+            backgroundImage: bg ? 'url(' + bg + ')'
+               : bgSuffix ? 'url(' + toAbsoluteServerURL(bgSuffix) + ')' : null,
+         };
       });
    };
 

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -813,12 +813,18 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
    };
 
    function initSliderConf (item, entity, key, def, attrs, value, default_request) {
-      return cacheInItem(item, key, {
-         max: attrs.max || def.max || 100,
-         min: attrs.min || def.min || 0,
-         step: attrs.step || def.step || 1,
-         value: value || +entity.state || def.value || 0,
-         request: def.request || default_request,
+      return cacheInItem(item, key, function () {
+         $timeout(function () {
+            item._sliderInited = true;
+         }, 50);
+
+         return {
+            max: attrs.max || def.max || 100,
+            min: attrs.min || def.min || 0,
+            step: attrs.step || def.step || 1,
+            value: value || +entity.state || def.value || 0,
+            request: def.request || default_request,
+         };
       });
    }
 
@@ -831,11 +837,6 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
          service: 'set_value',
          field: 'value',
       };
-
-      $timeout(function () {
-         item._sliderInited = true;
-      }, 50);
-
       return initSliderConf(item, entity, '_c_inputNumberSlider', def, attrs, value, default_request);
    };
 
@@ -850,13 +851,8 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
       };
 
       $timeout(function () {
-         entity.attributes._sliderInited = true;
          slider._sliderInited = true;
       }, 100);
-
-      $timeout(function () {
-         entity.attributes._sliderInited = true;
-      }, 0);
 
       return initSliderConf(item, entity, '_c_lightSlider_' + slider.field, def, attrs, value, default_request);
    };
@@ -870,10 +866,6 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
       if (!('volume_level' in attrs)) {
          return false;
       }
-
-      $timeout(function () {
-         entity.attributes._sliderInited = true;
-      }, 50);
 
       return initSliderConf(item, entity, '_c_volumeSlider', def, attrs, value, default_request);
    };
@@ -1020,7 +1012,7 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
    };
 
    $scope.volumeChanged = function (item, entity, conf) {
-      if (!entity.attributes._sliderInited) {
+      if (!item._sliderInited) {
          return;
       }
 
@@ -1043,7 +1035,7 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
       if (!slider._sliderInited) {
          return;
       }
-      if (!entity.attributes._sliderInited) {
+      if (!item._sliderInited) {
          return;
       }
 


### PR DESCRIPTION
fixes #464 
fixes #425 

@rchl , I have changed `eslint` to accept the `??` operator as of ECMA Script 2020. It transpiles just fine. But I am not aware of the issues this might cause on the rest of the linting.

Explanation of that operator:
https://github.com/tc39/proposal-nullish-coalescing

PS: Regarding the breaking change below, we should take a short time and think about which order is more suitable `def ?? attrs` or  `attrs ?? def`. I tend to think now that `def` should have priority, because it is user-defined. 

BREAKING CHANGE: The order of `attrs` and `def` is changed for a few sliders. This should not normally be a problem, because the user would only use one of the possibilities. But... just to give note on that.