### PR TITLE
refactor: cache sliders and unify handling of them

### DIFF
--- a/index.html.ejs
+++ b/index.html.ejs
@@ -567,7 +567,7 @@
 
                <div class="item-slider-title" ng-if="slider.title">
                   <span ng-bind="slider.title"></span>:
-                  <span ng-bind="getLightSliderValue(slider, _c)"></span>
+                  <span ng-bind="getLightSliderValue(_c)"></span>
                </div>
 
                <div class="item-slider">

--- a/index.html.ejs
+++ b/index.html.ejs
@@ -577,7 +577,7 @@
                          ng-on-touchstart="$event.stopPropagation()"
                          ng-on-touchmove="$event.stopPropagation()"
                          ng-on-pointerdown="$event.stopPropagation()"
-                         ng-change="lightSliderChanged(slider, item, entity, _c)"
+                         ng-change="lightSliderChanged(item, entity, slider, _c)"
                          step="{{ _c.step }}" ng-min="{{ _c.min }}" ng-max="{{ _c.max }}">
                </div>
             </div>

--- a/index.html.ejs
+++ b/index.html.ejs
@@ -567,7 +567,7 @@
 
                <div class="item-slider-title" ng-if="slider.title">
                   <span ng-bind="slider.title"></span>:
-                  <span ng-bind="getLightSliderValue(_c)"></span>
+                  <span ng-bind="getLightSliderValue(slider, _c)"></span>
                </div>
 
                <div class="item-slider">

--- a/index.html.ejs
+++ b/index.html.ejs
@@ -562,7 +562,7 @@
          <div ng-if="item.controlsEnabled" class="item-entity-sliders"
               ng-click="preventClick($event)">
             <div ng-repeat="slider in item.sliders track by $index"
-                 ng-if="(_c = getLightSliderConf(slider, entity))"
+                 ng-if="(_c = getLightSliderConf(item, entity, slider))"
                  class="item-slider-container">
 
                <div class="item-slider-title" ng-if="slider.title">

--- a/index.html.ejs
+++ b/index.html.ejs
@@ -572,7 +572,8 @@
 
                <div class="item-slider">
                   <input type="range"
-                         ng-model="_c.value"
+                         ng-model="_c.getSetValue"
+                         ng-model-options="{ getterSetter: true }"
                          ng-on-touchstart="$event.stopPropagation()"
                          ng-on-touchmove="$event.stopPropagation()"
                          ng-on-pointerdown="$event.stopPropagation()"

--- a/index.html.ejs
+++ b/index.html.ejs
@@ -982,7 +982,9 @@
                <tr ng-if="shouldShowVolumeSlider(entity) && (_c = getVolumeConf(item, entity))">
                   <td colspan="3" class="media-player-table--td-volume">
                      <div class="media-player--volume">
-                        <input type="range" ng-model="_c.value"
+                        <input type="range"
+                               ng-model="_c.getSetValue"
+                               ng-model-options="{ getterSetter: true }"
                                ng-change="volumeChanged(item, entity, _c)"
                                ng-on-touchstart="$event.stopPropagation()"
                                ng-on-touchmove="$event.stopPropagation()"

--- a/index.html.ejs
+++ b/index.html.ejs
@@ -729,7 +729,9 @@
          </div>
 
          <div class="item-slider" ng-if="(_c = getSliderConf(item, entity))">
-            <input type="range" ng-model="_c.value"
+            <input type="range"
+                   ng-model="_c.getSetValue"
+                   ng-model-options="{ getterSetter: true }"
                    ng-change="sliderChanged(item, entity, _c)"
                    ng-on-touchstart="$event.stopPropagation()"
                    ng-on-touchmove="$event.stopPropagation()"

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -814,8 +814,6 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
             max: config.max || attrs.max || defaults.max,
             step: config.step || attrs.step || defaults.step,
             request: config.request || defaults.request,
-            title: config.title || defaults.title,
-            formatValue: config.formatValue || defaults.formatValue,
             curValue: undefined, // current value received from HA
             oldValue: undefined, // last value received from HA
             newValue: undefined, // new value set by the user through the slider
@@ -858,12 +856,12 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
       return initSliderConf(item, entity, config, DEFAULT_VOLUME_SLIDER_OPTIONS);
    };
 
-   $scope.getLightSliderValue = function (conf) {
-      if (conf.formatValue) {
-         return conf.formatValue(conf);
+   $scope.getLightSliderValue = function (slider, conf) {
+      if (slider.formatValue) {
+         return slider.formatValue(conf);
       }
 
-      return conf.value;
+      return conf.getSetValue();
    };
 
    $scope.openLightSliders = function (item, entity) {

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -977,16 +977,15 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
 
    const setSliderValue = debounce(setSliderValueFn, 250);
 
-   function setSliderValueFn (item, entity, value) {
-      if (!value.request) {
+   function setSliderValueFn (item, entity, sliderConf) {
+      if (!sliderConf.request) {
          return;
       }
 
-      const conf = value.request;
       const serviceData = {};
-      serviceData[conf.field] = value.newValue;
+      serviceData[sliderConf.request.field] = sliderConf.newValue;
 
-      callService(item, conf.domain, conf.service, serviceData);
+      callService(item, sliderConf.request.domain, sliderConf.request.service, serviceData);
    }
 
    $scope.sliderChanged = function (item, entity, value) {
@@ -1014,18 +1013,12 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
       setSliderValue(item, entity, value);
    };
 
-   $scope.lightSliderChanged = function (slider, item, entity, value) {
-      if (!item._controlsInited) {
-         return;
-      }
-      if (!slider._sliderInited) {
-         return;
-      }
-      if (!item._sliderInited) {
+   $scope.lightSliderChanged = function (item, entity, slider, sliderConf) {
+      if (!item._controlsInited || !item._sliderInited || !slider._sliderInited) {
          return;
       }
 
-      setSliderValue(item, entity, value);
+      setSliderValue(item, entity, sliderConf);
    };
 
    $scope.toggleSwitch = function (item, entity, callback) {

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -814,6 +814,8 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
             max: config.max || attrs.max || defaults.max,
             step: config.step || attrs.step || defaults.step,
             request: config.request || defaults.request,
+            title: config.title || defaults.title,
+            formatValue: config.formatValue || defaults.formatValue,
             curValue: undefined, // current value received from HA
             oldValue: undefined, // last value received from HA
             newValue: undefined, // new value set by the user through the slider
@@ -856,12 +858,12 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
       return initSliderConf(item, entity, config, DEFAULT_VOLUME_SLIDER_OPTIONS);
    };
 
-   $scope.getLightSliderValue = function (slider, conf) {
-      if (slider.formatValue) {
-         return slider.formatValue(conf);
+   $scope.getLightSliderValue = function (conf) {
+      if (conf.formatValue) {
+         return conf.formatValue(conf);
       }
 
-      return conf.getSetValue();
+      return conf.value;
    };
 
    $scope.openLightSliders = function (item, entity) {

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -796,8 +796,18 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
       return page.header;
    };
 
-   function initSliderConf (item, entity, key, def, attrs, value, default_request) {
+   function initSliderConf (item, entity, def, value) {
+      const key = '_c_slider_' + def.field;
+
       return cacheInItem(item, key, function () {
+         const attrs = entity.attributes || {};
+         const value = +attrs[def.field] || 0;
+         const default_request = {
+            domain: 'input_number',
+            service: 'set_value',
+            field: 'value',
+         };
+
          $timeout(function () {
             item._sliderInited = true;
          }, 50);
@@ -814,44 +824,27 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
 
    $scope.getSliderConf = function (item, entity) {
       const def = item.slider || {};
-      const attrs = entity.attributes || {};
-      const value = +attrs[def.field] || 0;
-      const default_request = {
-         domain: 'input_number',
-         service: 'set_value',
-         field: 'value',
-      };
-      return initSliderConf(item, entity, '_c_inputNumberSlider', def, attrs, value, default_request);
+      return initSliderConf(item, entity, def);
    };
 
    $scope.getLightSliderConf = function (item, entity, slider) {
       const def = slider || {};
-      const attrs = entity.attributes;
-      const value = +attrs[def.field] || 0;
-      const default_request = {
-         domain: 'input_number',
-         service: 'set_value',
-         field: 'value',
-      };
 
       $timeout(function () {
          slider._sliderInited = true;
       }, 100);
 
-      return initSliderConf(item, entity, '_c_lightSlider_' + slider.field, def, attrs, value, default_request);
+      return initSliderConf(item, entity, def);
    };
 
    $scope.getVolumeConf = function (item, entity) {
-      const def = { max: 100, min: 0, step: 2 };
-      const attrs = entity.attributes;
-      const value = attrs.volume_level * 100 || 0;
-      const default_request = {};
+      const def = { max: 1.0, min: 0.0, step: 0.02, field: 'volume_level' };
 
-      if (!('volume_level' in attrs)) {
+      if (!('volume_level' in entity.attributes)) {
          return false;
       }
 
-      return initSliderConf(item, entity, '_c_volumeSlider', def, attrs, value, default_request);
+      return initSliderConf(item, entity, def);
    };
 
    $scope.getLightSliderValue = function (slider, conf) {
@@ -1001,7 +994,7 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
       }
 
       const value = {
-         value: conf.value / 100,
+         value: conf.value,
          request: {
             domain: 'media_player',
             service: 'volume_set',

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -996,21 +996,12 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
       setSliderValue(item, entity, sliderConf);
    };
 
-   $scope.volumeChanged = function (item, entity, conf) {
+   $scope.volumeChanged = function (item, entity, sliderConf) {
       if (!item._sliderInited) {
          return;
       }
 
-      const value = {
-         value: conf.value,
-         request: {
-            domain: 'media_player',
-            service: 'volume_set',
-            field: 'volume_level',
-         },
-      };
-
-      setSliderValue(item, entity, value);
+      setSliderValue(item, entity, sliderConf);
    };
 
    $scope.lightSliderChanged = function (item, entity, slider, sliderConf) {

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -797,12 +797,18 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
    };
 
    function initSliderConf (item, entity, key, def, attrs, value, default_request) {
-      return cacheInItem(item, key, {
-         max: attrs.max || def.max || 100,
-         min: attrs.min || def.min || 0,
-         step: attrs.step || def.step || 1,
-         value: value || +entity.state || def.value || 0,
-         request: def.request || default_request,
+      return cacheInItem(item, key, function () {
+         $timeout(function () {
+            item._sliderInited = true;
+         }, 50);
+
+         return {
+            max: attrs.max || def.max || 100,
+            min: attrs.min || def.min || 0,
+            step: attrs.step || def.step || 1,
+            value: value || +entity.state || def.value || 0,
+            request: def.request || default_request,
+         };
       });
    }
 
@@ -815,11 +821,6 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
          service: 'set_value',
          field: 'value',
       };
-
-      $timeout(function () {
-         item._sliderInited = true;
-      }, 50);
-
       return initSliderConf(item, entity, '_c_inputNumberSlider', def, attrs, value, default_request);
    };
 
@@ -834,13 +835,8 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
       };
 
       $timeout(function () {
-         entity.attributes._sliderInited = true;
          slider._sliderInited = true;
       }, 100);
-
-      $timeout(function () {
-         entity.attributes._sliderInited = true;
-      }, 0);
 
       return initSliderConf(item, entity, '_c_lightSlider_' + slider.field, def, attrs, value, default_request);
    };
@@ -854,10 +850,6 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
       if (!('volume_level' in attrs)) {
          return false;
       }
-
-      $timeout(function () {
-         entity.attributes._sliderInited = true;
-      }, 50);
 
       return initSliderConf(item, entity, '_c_volumeSlider', def, attrs, value, default_request);
    };
@@ -1004,7 +996,7 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
    };
 
    $scope.volumeChanged = function (item, entity, conf) {
-      if (!entity.attributes._sliderInited) {
+      if (!item._sliderInited) {
          return;
       }
 
@@ -1027,7 +1019,7 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
       if (!slider._sliderInited) {
          return;
       }
-      if (!entity.attributes._sliderInited) {
+      if (!item._sliderInited) {
          return;
       }
 

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -1,7 +1,7 @@
 import angular from 'angular';
 import Hammer from 'hammerjs';
 import { App } from '../app';
-import { TYPES, FEATURES, HEADER_ITEMS, MENU_POSITIONS, GROUP_ALIGNS, TRANSITIONS, MAPBOX_MAP, YANDEX_MAP } from '../globals/constants';
+import { TYPES, FEATURES, HEADER_ITEMS, MENU_POSITIONS, GROUP_ALIGNS, TRANSITIONS, MAPBOX_MAP, YANDEX_MAP, DEFAULT_SLIDER_OPTIONS, DEFAULT_LIGHT_SLIDER_OPTIONS, DEFAULT_VOLUME_SLIDER_OPTIONS } from '../globals/constants';
 import { debounce, leadZero, toAbsoluteServerURL } from '../globals/utils';
 import Noty from '../models/noty';
 
@@ -796,54 +796,49 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
       return page.header;
    };
 
-   function initSliderConf (item, entity, def, value) {
-      const key = '_c_slider_' + def.field;
+   function initSliderConf (item, entity, config, defaults) {
+      const key = '_c_slider_' + (config.field || defaults.field);
 
       return cacheInItem(item, key, function () {
          const attrs = entity.attributes || {};
-         const defaultRequest = {
-            domain: 'input_number',
-            service: 'set_value',
-            field: 'value',
-         };
 
          $timeout(function () {
             item._sliderInited = true;
          }, 50);
 
          return {
-            max: def.max || attrs.max || 100,
-            min: def.min || attrs.min || 0,
-            step: def.step || attrs.step || 1,
-            value: +attrs[def.field] || +entity.state || def.value || 0,
-            request: def.request || defaultRequest,
+            max: config.max || attrs.max || defaults.max,
+            min: config.min || attrs.min || defaults.min,
+            step: config.step || attrs.step || defaults.step,
+            value: config.value || +attrs[config.field] || +entity.state || defaults.value || +attrs[defaults.field],
+            request: config.request || defaults.request,
          };
       });
    }
 
    $scope.getSliderConf = function (item, entity) {
-      const def = item.slider || {};
-      return initSliderConf(item, entity, def);
+      const config = item.slider || {};
+      return initSliderConf(item, entity, config, DEFAULT_SLIDER_OPTIONS);
    };
 
    $scope.getLightSliderConf = function (item, entity, slider) {
-      const def = slider || {};
+      const config = slider || {};
 
       $timeout(function () {
          slider._sliderInited = true;
       }, 100);
 
-      return initSliderConf(item, entity, def);
+      return initSliderConf(item, entity, config, DEFAULT_LIGHT_SLIDER_OPTIONS);
    };
 
    $scope.getVolumeConf = function (item, entity) {
-      const def = { max: 1.0, min: 0.0, step: 0.02, field: 'volume_level' };
+      const config = { };
 
       if (!('volume_level' in entity.attributes)) {
          return false;
       }
 
-      return initSliderConf(item, entity, def);
+      return initSliderConf(item, entity, config, DEFAULT_VOLUME_SLIDER_OPTIONS);
    };
 
    $scope.getLightSliderValue = function (slider, conf) {

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -843,7 +843,6 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
 
    $scope.getLightSliderConf = function (item, entity, slider) {
       const config = slider || {};
-
       return initSliderConf(item, entity, config, DEFAULT_LIGHT_SLIDER_OPTIONS);
    };
 

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -806,13 +806,21 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
             item._sliderInited = true;
          }, 50);
 
-         return {
-            max: config.max || attrs.max || defaults.max,
+         const sliderConf = {
             min: config.min || attrs.min || defaults.min,
+            max: config.max || attrs.max || defaults.max,
             step: config.step || attrs.step || defaults.step,
-            value: config.value || +attrs[config.field] || +entity.state || defaults.value || +attrs[defaults.field],
             request: config.request || defaults.request,
          };
+         sliderConf.getSetValue = function (newValue) {
+            if (arguments.length) {
+               sliderConf.newValue = newValue;
+            }
+            sliderConf.value = config.value || +entity.attributes[config.field] || +entity.state || defaults.value || +entity.attributes[defaults.field];
+            return (sliderConf.oldValue !== sliderConf.value) ? (sliderConf.oldValue = sliderConf.value) : sliderConf.newValue;
+         };
+         sliderConf.getSetValue();
+         return sliderConf;
       });
    }
 
@@ -969,7 +977,7 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
 
       const conf = value.request;
       const serviceData = {};
-      serviceData[conf.field] = value.value;
+      serviceData[conf.field] = value.newValue;
 
       callService(item, conf.domain, conf.service, serviceData);
    }

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -861,7 +861,7 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
          return slider.formatValue(conf);
       }
 
-      return conf.getSetValue();
+      return conf.value;
    };
 
    $scope.openLightSliders = function (item, entity) {

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -796,64 +796,41 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
       return page.header;
    };
 
-   $scope.getSliderConf = function (item, entity) {
-      const key = '_c';
-
-      if (!entity.attributes) {
-         entity.attributes = {};
-      }
-      if (entity.attributes[key]) {
-         return entity.attributes[key];
-      }
-
-      const def = item.slider || {};
-      const attrs = entity.attributes || {};
-      const value = +attrs[def.field] || 0;
-
-      entity.attributes[key] = {
+   function initSliderConf (item, entity, key, def, attrs, value, default_request) {
+      return cacheInItem(item, key, {
          max: attrs.max || def.max || 100,
          min: attrs.min || def.min || 0,
          step: attrs.step || def.step || 1,
          value: value || +entity.state || def.value || 0,
-         request: def.request || {
-            domain: 'input_number',
-            service: 'set_value',
-            field: 'value',
-         },
+         request: def.request || default_request,
+      });
+   }
+
+   $scope.getSliderConf = function (item, entity) {
+      const def = item.slider || {};
+      const attrs = entity.attributes || {};
+      const value = +attrs[def.field] || 0;
+      const default_request = {
+         domain: 'input_number',
+         service: 'set_value',
+         field: 'value',
       };
 
       $timeout(function () {
          item._sliderInited = true;
       }, 50);
 
-      return entity.attributes[key];
+      return initSliderConf(item, entity, '_c_inputNumberSlider', def, attrs, value, default_request);
    };
 
    $scope.getLightSliderConf = function (slider, entity) {
-      const key = '_c_' + slider.field;
-
-      if (!entity.attributes) {
-         entity.attributes = {};
-      }
-      if (entity.attributes[key]) {
-         return entity.attributes[key];
-      }
-
-
       const def = slider || {};
       const attrs = entity.attributes;
       const value = +attrs[def.field] || 0;
-
-      entity.attributes[key] = {
-         max: def.max || attrs.max || 100,
-         min: def.min || attrs.min || 0,
-         step: def.step || attrs.step || 1,
-         value: value || def.min || attrs.min || 0,
-         request: def.request || {
-            domain: 'input_number',
-            service: 'set_value',
-            field: 'value',
-         },
+      const default_request = {
+         domain: 'input_number',
+         service: 'set_value',
+         field: 'value',
       };
 
       $timeout(function () {
@@ -865,37 +842,24 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
          entity.attributes._sliderInited = true;
       }, 0);
 
-      return entity.attributes[key];
+      return initSliderConf(slider, entity, '_c_lightSlider', def, attrs, value, default_request);
    };
 
    $scope.getVolumeConf = function (item, entity) {
-      if (!entity.attributes) {
-         entity.attributes = {};
-      }
-      if (entity.attributes._c) {
-         return entity.attributes._c;
-      }
-
       const def = { max: 100, min: 0, step: 2 };
       const attrs = entity.attributes;
       const value = attrs.volume_level * 100 || 0;
+      const default_request = {};
 
       if (!('volume_level' in attrs)) {
          return false;
       }
 
-      entity.attributes._c = {
-         max: attrs.max || def.max || 100,
-         min: attrs.min || def.min || 0,
-         step: attrs.step || def.step || 1,
-         value: value || 0,
-      };
-
       $timeout(function () {
          entity.attributes._sliderInited = true;
       }, 50);
 
-      return entity.attributes._c;
+      return initSliderConf(item, entity, '_c_volumeSlider', def, attrs, value, default_request);
    };
 
    $scope.getLightSliderValue = function (slider, conf) {

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -823,7 +823,7 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
       return initSliderConf(item, entity, '_c_inputNumberSlider', def, attrs, value, default_request);
    };
 
-   $scope.getLightSliderConf = function (slider, entity) {
+   $scope.getLightSliderConf = function (item, entity, slider) {
       const def = slider || {};
       const attrs = entity.attributes;
       const value = +attrs[def.field] || 0;
@@ -842,7 +842,7 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
          entity.attributes._sliderInited = true;
       }, 0);
 
-      return initSliderConf(slider, entity, '_c_lightSlider', def, attrs, value, default_request);
+      return initSliderConf(item, entity, '_c_lightSlider_' + slider.field, def, attrs, value, default_request);
    };
 
    $scope.getVolumeConf = function (item, entity) {

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -801,7 +801,6 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
 
       return cacheInItem(item, key, function () {
          const attrs = entity.attributes || {};
-         const value = +attrs[def.field] || 0;
          const default_request = {
             domain: 'input_number',
             service: 'set_value',
@@ -813,10 +812,10 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
          }, 50);
 
          return {
-            max: attrs.max || def.max || 100,
-            min: attrs.min || def.min || 0,
-            step: attrs.step || def.step || 1,
-            value: value || +entity.state || def.value || 0,
+            max: def.max || attrs.max || 100,
+            min: def.min || attrs.min || 0,
+            step: def.step || attrs.step || 1,
+            value: +attrs[def.field] || +entity.state || def.value || 0,
             request: def.request || default_request,
          };
       });

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -824,7 +824,7 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
                sliderConf.newValue = newValue;
                sliderConf.value = newValue;
             } else {
-               sliderConf.curValue = config.value || +entity.attributes[config.field] || +entity.state || defaults.value || +entity.attributes[defaults.field];
+               sliderConf.curValue = +entity.attributes[config.field] || +entity.attributes[defaults.field] || +entity.state || config.value || defaults.value || config.min || defaults.min || entity.attributes.min || 0;
                if (sliderConf.oldValue !== sliderConf.curValue) {
                   sliderConf.oldValue = sliderConf.curValue;
                   sliderConf.value = sliderConf.curValue;

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -805,21 +805,33 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
          $timeout(function () {
             item._sliderInited = true;
          }, 50);
+         $timeout(function () {
+            config._sliderInited = true;
+         }, 100);
 
          const sliderConf = {
             min: config.min || attrs.min || defaults.min,
             max: config.max || attrs.max || defaults.max,
             step: config.step || attrs.step || defaults.step,
             request: config.request || defaults.request,
+            curValue: undefined, // current value received from HA
+            oldValue: undefined, // last value received from HA
+            newValue: undefined, // new value set by the user through the slider
+            value: undefined, // the most current value from all the above
          };
          sliderConf.getSetValue = function (newValue) {
             if (arguments.length) {
                sliderConf.newValue = newValue;
+               sliderConf.value = newValue;
+            } else {
+               sliderConf.curValue = config.value || +entity.attributes[config.field] || +entity.state || defaults.value || +entity.attributes[defaults.field];
+               if (sliderConf.oldValue !== sliderConf.curValue) {
+                  sliderConf.oldValue = sliderConf.curValue;
+                  sliderConf.value = sliderConf.curValue;
+               }
             }
-            sliderConf.value = config.value || +entity.attributes[config.field] || +entity.state || defaults.value || +entity.attributes[defaults.field];
-            return (sliderConf.oldValue !== sliderConf.value) ? (sliderConf.oldValue = sliderConf.value) : sliderConf.newValue;
+            return sliderConf.value;
          };
-         sliderConf.getSetValue();
          return sliderConf;
       });
    }
@@ -831,10 +843,6 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
 
    $scope.getLightSliderConf = function (item, entity, slider) {
       const config = slider || {};
-
-      $timeout(function () {
-         slider._sliderInited = true;
-      }, 100);
 
       return initSliderConf(item, entity, config, DEFAULT_LIGHT_SLIDER_OPTIONS);
    };
@@ -854,7 +862,7 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
          return slider.formatValue(conf);
       }
 
-      return conf.value;
+      return conf.getSetValue();
    };
 
    $scope.openLightSliders = function (item, entity) {

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -988,12 +988,12 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
       callService(item, sliderConf.request.domain, sliderConf.request.service, serviceData);
    }
 
-   $scope.sliderChanged = function (item, entity, value) {
+   $scope.sliderChanged = function (item, entity, sliderConf) {
       if (!item._sliderInited) {
          return;
       }
 
-      setSliderValue(item, entity, value);
+      setSliderValue(item, entity, sliderConf);
    };
 
    $scope.volumeChanged = function (item, entity, conf) {

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -801,7 +801,7 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
 
       return cacheInItem(item, key, function () {
          const attrs = entity.attributes || {};
-         const default_request = {
+         const defaultRequest = {
             domain: 'input_number',
             service: 'set_value',
             field: 'value',
@@ -816,7 +816,7 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
             min: def.min || attrs.min || 0,
             step: def.step || attrs.step || 1,
             value: +attrs[def.field] || +entity.state || def.value || 0,
-            request: def.request || default_request,
+            request: def.request || defaultRequest,
          };
       });
    }

--- a/scripts/globals/constants.js
+++ b/scripts/globals/constants.js
@@ -227,8 +227,8 @@ export const MINIMAL_CHART_OPTIONS = {
 };
 
 export const DEFAULT_SLIDER_OPTIONS = {
-   min: 0,
    max: 100,
+   min: 0,
    step: 1,
    field: 'value',
    request: {
@@ -239,14 +239,10 @@ export const DEFAULT_SLIDER_OPTIONS = {
 };
 
 export const DEFAULT_LIGHT_SLIDER_OPTIONS = {
-   min: 0,
    max: 255,
+   min: 0,
    step: 1,
    field: 'brightness',
-   title: 'Brightness',
-   formatValue: function (conf) {
-      return conf.value;
-   },
    request: {
       domain: 'light',
       service: 'turn_on',
@@ -255,8 +251,8 @@ export const DEFAULT_LIGHT_SLIDER_OPTIONS = {
 };
 
 export const DEFAULT_VOLUME_SLIDER_OPTIONS = {
-   min: 0.0,
    max: 1.0,
+   min: 0.0,
    step: 0.02,
    field: 'volume_level',
    request: {

--- a/scripts/globals/constants.js
+++ b/scripts/globals/constants.js
@@ -225,3 +225,39 @@ export const MINIMAL_CHART_OPTIONS = {
       },
    },
 };
+
+export const DEFAULT_SLIDER_OPTIONS = {
+   max: 100,
+   min: 0,
+   step: 1,
+   field: 'value',
+   request: {
+      domain: 'input_number',
+      service: 'set_value',
+      field: 'value',
+   },
+};
+
+export const DEFAULT_LIGHT_SLIDER_OPTIONS = {
+   max: 255,
+   min: 0,
+   step: 1,
+   field: 'brightness',
+   request: {
+      domain: 'light',
+      service: 'turn_on',
+      field: 'brightness',
+   },
+};
+
+export const DEFAULT_VOLUME_SLIDER_OPTIONS = {
+   max: 1.0,
+   min: 0.0,
+   step: 0.02,
+   field: 'volume_level',
+   request: {
+      domain: 'media_player',
+      service: 'volume_set',
+      field: 'volume_level',
+   },
+};

--- a/scripts/globals/constants.js
+++ b/scripts/globals/constants.js
@@ -227,8 +227,8 @@ export const MINIMAL_CHART_OPTIONS = {
 };
 
 export const DEFAULT_SLIDER_OPTIONS = {
-   max: 100,
    min: 0,
+   max: 100,
    step: 1,
    field: 'value',
    request: {
@@ -239,10 +239,14 @@ export const DEFAULT_SLIDER_OPTIONS = {
 };
 
 export const DEFAULT_LIGHT_SLIDER_OPTIONS = {
-   max: 255,
    min: 0,
+   max: 255,
    step: 1,
    field: 'brightness',
+   title: 'Brightness',
+   formatValue: function (conf) {
+      return conf.value;
+   },
    request: {
       domain: 'light',
       service: 'turn_on',
@@ -251,8 +255,8 @@ export const DEFAULT_LIGHT_SLIDER_OPTIONS = {
 };
 
 export const DEFAULT_VOLUME_SLIDER_OPTIONS = {
-   max: 1.0,
    min: 0.0,
+   max: 1.0,
    step: 0.02,
    field: 'volume_level',
    request: {

--- a/styles/main.less
+++ b/styles/main.less
@@ -1561,6 +1561,7 @@ camera_stream {
    top: 5px;
    left: 5px;
    right: 5px;
+   z-index: 2;
 
    input {
       box-sizing: border-box;


### PR DESCRIPTION
This cleans up slider code and uses the new `cacheInItem` 

BREAKING CHANGE: The order of attrs and def is changed for a few sliders. This should not normally be a problem, because user would only use one of the possibilities. But... just to give note on that.

