### PR TITLE
fix(LIGHT): show color picker based on feature check

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,6 +1,6 @@
 env:
   browser: true
-  es2017: true
+  es2020: true
   node: true
 parserOptions:
   sourceType: module

--- a/README.md
+++ b/README.md
@@ -356,10 +356,10 @@ Tile Object. [Click here for some real-life examples](TILE_EXAMPLES.md)
    /** type: LIGHT **/
    /* sliders: list of slider object. See slider documentation below */
    sliders: [{}],
-   /* colorpicker: whether or not the color picker should be shown. 
+   /* colorpicker: whether or not the color picker should be shown.
     * Valid options: true, false, function. Default: auto-detected
     */
-   colorpicker: true,
+   colorpicker: false,
    /** type: POPUP_IFRAME **/
    url: String || Function,
    /* optional */

--- a/README.md
+++ b/README.md
@@ -356,7 +356,10 @@ Tile Object. [Click here for some real-life examples](TILE_EXAMPLES.md)
    /** type: LIGHT **/
    /* sliders: list of slider object. See slider documentation below */
    sliders: [{}],
-   
+   /* colorpicker: whether or not the color picker should be shown. 
+    * Valid options: true, false, function. Default: auto-detected
+    */
+   colorpicker: true,
    /** type: POPUP_IFRAME **/
    url: String || Function,
    /* optional */

--- a/README.md
+++ b/README.md
@@ -357,11 +357,6 @@ Tile Object. [Click here for some real-life examples](TILE_EXAMPLES.md)
    /* sliders: list of slider object. See slider documentation below */
    sliders: [{}],
    
-   /* colorpicker: whether or not the color picker should be used. 
-    * Only works with lights that have the rgb_color attribute 
-    * Valid options: true, false 
-    */
-   colorpicker: true,
    /** type: POPUP_IFRAME **/
    url: String || Function,
    /* optional */

--- a/TILE_EXAMPLES.md
+++ b/TILE_EXAMPLES.md
@@ -414,7 +414,6 @@ Light switch. You can optionally define sliders to control colour temperature or
          }
       }
    ],
-   colorpicker: true
 }
 ```
 

--- a/index.html.ejs
+++ b/index.html.ejs
@@ -582,7 +582,7 @@
                </div>
             </div>
 
-            <div ng-if="item.colorpicker" class="item-entity-colorpicker">
+            <div ng-if="supportsFeature(FEATURES.LIGHT.COLOR, entity)" class="item-entity-colorpicker">
                <span>Color:</span>
                <input color-picker
                   color-picker-model="getRGBStringFromArray(entity.attributes.rgb_color)"

--- a/index.html.ejs
+++ b/index.html.ejs
@@ -582,7 +582,7 @@
                </div>
             </div>
 
-            <div ng-if="supportsFeature(FEATURES.LIGHT.COLOR, entity)" class="item-entity-colorpicker">
+            <div ng-if="itemField('colorpicker', item, entity)" class="item-entity-colorpicker">
                <span>Color:</span>
                <input color-picker
                   color-picker-model="getRGBStringFromArray(entity.attributes.rgb_color)"

--- a/scripts/controllers/main-utilities.js
+++ b/scripts/controllers/main-utilities.js
@@ -1,0 +1,41 @@
+import angular from 'angular';
+import { TILE_DEFAULTS, TYPES } from '../globals/constants';
+
+export function mergeConfigDefaults (pages) {
+   for (const page of pages) {
+      for (const group of page.groups) {
+         mergeTileListDefaults(group.items);
+      }
+   }
+   return pages;
+}
+
+function mergeTileListDefaults (tiles) {
+   if (!Array.isArray(tiles)) {
+      return;
+   }
+   for (const [index, tile] of tiles.entries()) {
+      if (tile.type in TILE_DEFAULTS) {
+         tiles[index] = mergeTileDefaults(tile);
+      }
+      switch (tile.type) {
+         case TYPES.CAMERA_THUMBNAIL:
+            tile.fullscreen = mergeTileDefaults(tile.fullscreen);
+            break;
+         case TYPES.DOOR_ENTRY:
+            if (tile.layout?.camera) {
+               tile.layout.camera = mergeTileDefaults(tile.layout.camera);
+            }
+            mergeTileListDefaults(tile.layout?.tiles);
+            break;
+         case TYPES.POPUP:
+            mergeTileListDefaults(tile.popup?.items);
+            break;
+      }
+   }
+   return tiles;
+}
+
+function mergeTileDefaults (tile) {
+   return angular.merge({}, TILE_DEFAULTS[tile.type], tile);
+}

--- a/scripts/controllers/main-utilities.js
+++ b/scripts/controllers/main-utilities.js
@@ -15,10 +15,10 @@ function mergeTileListDefaults (tiles) {
       return;
    }
    for (const [index, tile] of tiles.entries()) {
-      if (tile.type in TILE_DEFAULTS) {
-         tiles[index] = mergeTileDefaults(tile);
-      }
+      tiles[index] = mergeTileDefaults(tile);
       switch (tile.type) {
+         case TYPES.CAMERA:
+         case TYPES.CAMERA_STREAM:
          case TYPES.CAMERA_THUMBNAIL:
             tile.fullscreen = mergeTileDefaults(tile.fullscreen);
             break;
@@ -37,5 +37,8 @@ function mergeTileListDefaults (tiles) {
 }
 
 function mergeTileDefaults (tile) {
-   return angular.merge({}, TILE_DEFAULTS[tile.type], tile);
+   if (tile && tile.type in TILE_DEFAULTS) {
+      return angular.merge({}, TILE_DEFAULTS[tile.type], tile);
+   }
+   return tile;
 }

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -919,7 +919,7 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
    };
 
    $scope.getGaugeField = function (field, item, entity) {
-      return parseFieldValue(item.settings[field], item, entity);
+      return getItemFieldValue(`settings.${field}`, item, entity);
    };
 
    $scope.itemURL = function (item, entity) {

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -864,7 +864,7 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
    };
 
    $scope.openLightSliders = function (item, entity) {
-      if ((!item.sliders || !item.sliders.length) && !item.colorpicker) {
+      if ((!item.sliders || !item.sliders.length) && !$scope.supportsFeature(FEATURES.LIGHT.COLOR, entity)) {
          return;
       }
 

--- a/scripts/globals/constants.js
+++ b/scripts/globals/constants.js
@@ -1,4 +1,4 @@
-import { timeAgo } from './utils';
+import { supportsFeature, timeAgo } from './utils';
 
 export const CLASS_BIG = '-big-entity';
 export const CLASS_SMALL = '-small-entity';
@@ -274,5 +274,27 @@ export const DEFAULT_VOLUME_SLIDER_OPTIONS = {
       domain: 'media_player',
       service: 'volume_set',
       field: 'volume_level',
+   },
+};
+
+export const TILE_DEFAULTS = {
+   [TYPES.GAUGE]: {
+      settings: {
+         backgroundColor: 'rgba(0, 0, 0, 0.1)',
+         foregroundColor: 'rgba(0, 150, 136, 1)',
+         size (item) {
+            return .8 * (window.CONFIG.tileSize * (item.height < item.width ? item.height : item.width));
+         },
+         duration: 1500,
+         thick: 6,
+         type: 'full',
+         min: 0,
+         max: 100,
+         cap: 'butt',
+         thresholds: {},
+      },
+   },
+   [TYPES.LIGHT]: {
+      colorpicker: (item, entity) => supportsFeature(FEATURES.LIGHT.COLOR, entity),
    },
 };

--- a/scripts/globals/constants.js
+++ b/scripts/globals/constants.js
@@ -87,7 +87,14 @@ export const FEATURES = {
       ARM_CUSTOM_BYPASS: 16,
    },
    LIGHT: {
+      // https://github.com/home-assistant/core/blob/dev/homeassistant/components/light/__init__.py
       BRIGHTNESS: 1,
+      COLOR_TEMP: 2,
+      EFFECT: 4,
+      FLASH: 8,
+      COLOR: 16,
+      TRANSITION: 32,
+      WHITE_VALUE: 128,
    },
    MEDIA_PLAYER: {
       PAUSE: 1,

--- a/scripts/globals/utils.js
+++ b/scripts/globals/utils.js
@@ -131,11 +131,6 @@ export const toAbsoluteServerURL = function (path) {
 };
 
 export function supportsFeature (feature, entity) {
-   if (!('supported_features' in entity.attributes)) {
-      return false;
-   }
-
-   const features = entity.attributes.supported_features;
-
-   return (features | feature) === features;
+   return 'supported_features' in entity.attributes
+      && (entity.attributes.supported_features & feature) !== 0;
 }

--- a/scripts/globals/utils.js
+++ b/scripts/globals/utils.js
@@ -129,3 +129,13 @@ export const toAbsoluteServerURL = function (path) {
    // Replace extra forward slashes but not in protocol.
    return url.replace(/([^:])\/+/g, '$1/');
 };
+
+export function supportsFeature (feature, entity) {
+   if (!('supported_features' in entity.attributes)) {
+      return false;
+   }
+
+   const features = entity.attributes.supported_features;
+
+   return (features | feature) === features;
+}


### PR DESCRIPTION
This is a behavior change since now even if the user doesn't define
sliders and the light supports color change, then picker will still show up
on long press.

We maybe should leave support for "item.colorpicker" to be able to
override it to "false" but not sure if it's worth it.

@akloeckner 