### PR TITLE
fix: sliders to allow zero values

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,6 +1,6 @@
 env:
   browser: true
-  es2017: true
+  es2020: true
   node: true
 parserOptions:
   sourceType: module

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -809,8 +809,8 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
 
          const attrs = entity.attributes || {};
          const sliderConf = {
-            min: config.min || attrs.min || defaults.min,
-            max: config.max || attrs.max || defaults.max,
+            min: config.min ?? attrs.min ?? defaults.min,
+            max: config.max ?? attrs.max ?? defaults.max,
             step: config.step || attrs.step || defaults.step,
             request: config.request || defaults.request,
             curValue: undefined, // current value received from HA
@@ -824,9 +824,11 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
                sliderConf.value = newValue;
             } else {
                const { attributes, state } = entity;
-               sliderConf.curValue = +attributes[config.field] || +attributes[defaults.field] || +state
-                  || config.value || defaults.value
-                  || config.min || defaults.min || attributes.min || 0;
+               sliderConf.curValue = (!isNaN(+attributes[config.field]) ? +attributes[config.field] : null)
+                  ?? (!isNaN(+attributes[defaults.field]) ? +attributes[defaults.field] : null)
+                  ?? (!isNaN(+state) ? +state : null)
+                  ?? config.value ?? defaults.value
+                  ?? config.min ?? defaults.min ?? attributes.min ?? 0;
                if (sliderConf.oldValue !== sliderConf.curValue) {
                   sliderConf.oldValue = sliderConf.curValue;
                   sliderConf.value = sliderConf.curValue;

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -796,6 +796,10 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
       return page.header;
    };
 
+   function toSafeNumber (value) {
+      return !isNaN(+value) ? +value : null;
+   }
+
    function initSliderConf (item, entity, config, defaults) {
       const key = '_c_slider_' + (config.field || defaults.field);
 
@@ -824,11 +828,9 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
                sliderConf.value = newValue;
             } else {
                const { attributes, state } = entity;
-               sliderConf.curValue = (!isNaN(+attributes[config.field]) ? +attributes[config.field] : null)
-                  ?? (!isNaN(+attributes[defaults.field]) ? +attributes[defaults.field] : null)
-                  ?? (!isNaN(+state) ? +state : null)
+               sliderConf.curValue = toSafeNumber(+attributes[config.field]) ?? toSafeNumber(+attributes[defaults.field]) ?? toSafeNumber(+state)
                   ?? config.value ?? defaults.value
-                  ?? config.min ?? defaults.min ?? attributes.min ?? 0;
+                  ?? config.min ?? attributes.min ?? defaults.min ?? 0;
                if (sliderConf.oldValue !== sliderConf.curValue) {
                   sliderConf.oldValue = sliderConf.curValue;
                   sliderConf.value = sliderConf.curValue;


### PR DESCRIPTION
Using ES2020's nullish coalescing operator `??`. It is just like `||`, but it only falls back to the next default, if the left operand is `null` or `undefined`. It also allows `NaN`, that's why the code becomes a bit more complex.

I tested with this input_number:
```
input_number:
  test_slider:
    name: Dummy for TileBoard
    min: -10
    max: 10
    step: 1
    mode: box
```

And this slider:
```
                  {
                     position: [2, 2],
                     id: 'input_number.test_slider',
                     type: TYPES.SLIDER,
                     state: false,
                     slider: {
                        max: 10,
                        min: -10,
                        step: 1,
                     }
                  },
```

The new code is at least useful for the `min` and `max` values, because those were not used if set to `0`. It fell back to the `attributes` then. 

I also tested the issue from #464 and don't seem to be quite able to reproduce. I did notice, however, that setting the slider to `zero` would make it jump to the `min` value. That is fixed now. @rtsam, do you have the possibility to check if this resolves your issue?