### PR TITLE
fix: unify examples

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -24,7 +24,7 @@ var CONFIG = {
 ## Connection <sup>[back to toc](#table-of-contents)</sup>
 
 ```js
-/*
+*/
    serverUrl: 'http://' + location.hostname + ':8123',
    wsUrl: 'ws://' + location.hostname + ':8123/api/websocket',
    debug: false, // Prints entities and state change info to the console.
@@ -34,7 +34,7 @@ var CONFIG = {
 > :warning: **Security advice**:
 > The following authentication info will be readable in the source code. So, make sure you are either not using it, or, your TileBoard is not exposed to untrusted persons (e.g. on the internet)!
 ```js
-/*
+*/
    authToken: null, // optional long-lived token (CAUTION: only if TileBoard is not exposed to the internet)
    //googleApiKey: "XXXXXXXXXX", // Required if you are using Google Maps for device tracker
    //mapboxToken: "XXXXXXXXXX", // Required if you are using Mapbox for device tracker
@@ -44,7 +44,7 @@ var CONFIG = {
 ## Basic appearance <sup>[back to toc](#table-of-contents)</sup>
 
 ```js
-/*
+*/
    timeFormat: 24,
    menuPosition: MENU_POSITIONS.LEFT, // or BOTTOM
    hideScrollbar: false, // horizontal scrollbar
@@ -76,7 +76,7 @@ var CONFIG = {
 ## Global interactive elements <sup>[back to toc](#table-of-contents)</sup>
 
 ```js
-/*
+*/
    /* events: A list of events. See documentation on Events below */
    events: [],
    onReady: function () {},

--- a/config.example.js
+++ b/config.example.js
@@ -10,7 +10,7 @@ Make sure you use real IDs from your HA entities.
 1. [General options](#general-options-back-to-toc)
 2. [Structure of a TileBoard layout](#structure-of-a-tileboard-layout-back-to-toc)
 
-## General options <sup>[back to toc](#table-of-contents)</sup>
+# General options <sup>[back to toc](#table-of-contents)</sup>
 
 
 `config.js` will initialize a global `CONFIG` object with the following fields to influence general behavior:
@@ -21,7 +21,7 @@ var CONFIG = {
 /*
 ```
 
-### Connection settings <sup>[back to toc](#table-of-contents)</sup>
+## Connection settings <sup>[back to toc](#table-of-contents)</sup>
 
 ```js
 /*
@@ -41,7 +41,7 @@ var CONFIG = {
 /*
 ```
 
-### Basic appearance settings <sup>[back to toc](#table-of-contents)</sup>
+## Basic appearance settings <sup>[back to toc](#table-of-contents)</sup>
 
 ```js
 /*
@@ -73,7 +73,7 @@ var CONFIG = {
 /*
 ```
 
-### Global interactive elements <sup>[back to toc](#table-of-contents)</sup>
+## Global interactive elements <sup>[back to toc](#table-of-contents)</sup>
 
 ```js
 /*
@@ -83,7 +83,7 @@ var CONFIG = {
 /*
 ```
 
-## Structure of a TileBoard layout <sup>[back to toc](#table-of-contents)</sup>
+# Structure of a TileBoard layout <sup>[back to toc](#table-of-contents)</sup>
 
 The following fields are used to influence the actual appearance of your TileBoard:
 
@@ -108,7 +108,7 @@ The following fields are used to influence the actual appearance of your TileBoa
 /*
 ```
 
-### Pages
+## Pages
 
 Page object can have the following fields:
 
@@ -264,33 +264,38 @@ Page object can have the following fields:
                      title: 'Custom switch',
                      icons: {'off': 'mdi-volume-off', 'on': 'mdi-volume-high'}
                   },
-                  {
-                     position: [0, 1],
-                     type: TYPES.ALARM,
-                     // id: "alarm_control_panel.home_alarm",
-                     id: { state: 'disarmed' }, // replace it with real string id
-                     title: 'Home Alarm',
-                     icons: {
-                        arming: 'mdi-bell-outline',
-                        disarmed: 'mdi-bell-off',
-                        pending: 'mdi-bell',
-                        armed_custom_bypass: 'mdi-bell-check',
-                        armed_home: 'mdi-bell-plus',
-                        armed_night: 'mdi-bell-sleep',
-                        armed_away: 'mdi-bell',
-                        triggered: 'mdi-bell-ring',
-                     },
-                     states: {
-                        arming: 'Arming',
-                        disarmed: 'Disarmed',
-                        pending: 'Pending',
-                        armed_custom_bypass: 'Armed custom bypass',
-                        armed_home: 'Armed home',
-                        armed_night: 'Armed night',
-                        armed_away: 'Armed away',
-                        triggered: 'Triggered',
-                     },
-                  },
+/*
+```                  
+                  
+#### ALARM
+
+![ALARM](images/tile-screenshots/ALARM.png)
+
+```js 
+*/
+{
+   position: [0, 3],
+   type: TYPES.ALARM,
+   title: 'Alarm',
+   //id: "alarm_control_panel.home_alarm",
+   id: id: { state: 'disarmed' }, // replace it with real string id
+   icons: {
+      disarmed: 'mdi-bell-off',
+      pending: 'mdi-bell',
+      armed_home: 'mdi-bell-plus',
+      armed_away: 'mdi-bell',
+      triggered: 'mdi-bell-ring'
+   },
+   states: {
+      disarmed: 'Disarmed',
+      pending: 'Pending',
+      armed_home: 'Armed home',
+      armed_away: 'Armed away',
+      triggered: 'Triggered'
+   }
+},
+/*
+```
 
                ],
             },
@@ -412,3 +417,6 @@ Page object can have the following fields:
       }
    ],
 }
+/*
+```
+*/

--- a/config.example.js
+++ b/config.example.js
@@ -21,7 +21,7 @@ var CONFIG = {
 /*
 ```
 
-## Connection settings <sup>[back to toc](#table-of-contents)</sup>
+## Connection <sup>[back to toc](#table-of-contents)</sup>
 
 ```js
 /*
@@ -41,7 +41,7 @@ var CONFIG = {
 /*
 ```
 
-## Basic appearance settings <sup>[back to toc](#table-of-contents)</sup>
+## Basic appearance <sup>[back to toc](#table-of-contents)</sup>
 
 ```js
 /*

--- a/config.example.js
+++ b/config.example.js
@@ -108,9 +108,11 @@ The following fields are used to influence the actual appearance of your TileBoa
 /*
 ```
 
-## Pages
+## Header
 
-Page object can have the following fields:
+The header is always visible in your TileBoard. 
+You can configure it with various elements.
+The following settings are possible:
 
 ```js 
 */
@@ -187,24 +189,61 @@ Page object can have the following fields:
          { bg: 'images/bg3.jpg' }
       ]
    },*/
+/*
+```
 
+## Pages
+
+Pages represent a single view of your TileBoard.
+You can navigate between pages using the navigation menu, which is located on the left or on the bottom of the screen.
+The `pages` setting of your `CONFIG` is a list of individual page objects.
+The following settings are available for each page object.
+
+```js 
+*/
    pages: [
       {
          title: 'Main page',
          bg: 'images/bg1.jpeg',
          icon: 'mdi-home-outline', // home icon
+         groups: [], // list of group object as described next
+/*
+```
+
+## Groups
+
+Within a page, tiles are organized in groups. 
+The groups are aligned either horizontally or vertically.
+The `groups` setting of each `page` is a list of individual group objects.
+The following settings are available for each group object.
+
+```js 
+*/
          groups: [
             {
                title: 'First group',
                width: 2,
                height: 3,
+               items: [], // list of tile (or item) objects as described next
+/*
+```
+
+## Tiles
+
+Tiles (or items) are the basic elements of a TileBoard.
+As described above, they are organized in low-level groups and high-level pages.
+The `items` setting of each `group` is a list of individual tile objects.
+The following general settings are available for any tile object.
+```js 
+*/
                items: [
                   {
-                     position: [0, 0],
-                     width: 2,
                      type: TYPES.TEXT_LIST,
+                     position: [0, 0],
                      id: {}, // using empty object for an unknown id
-                     state: false, // disable state element
+                     width: 2,
+                     height: 1, 
+                     state: false, // disable state element             
                      list: [
                         {
                            title: 'Sun.sun state',
@@ -218,6 +257,43 @@ Page object can have the following fields:
                         }
                      ]
                   },
+/*
+```
+
+# Tile types
+
+In the following, the available tile types are explained as examples along with their specific settings.
+
+## ALARM
+
+![ALARM](images/tile-screenshots/ALARM.png)
+
+```js 
+*/
+{
+   position: [0, 3],
+   type: TYPES.ALARM,
+   title: 'Alarm',
+   //id: "alarm_control_panel.home_alarm",
+   id: id: { state: 'disarmed' }, // replace it with real string id
+   icons: {
+      disarmed: 'mdi-bell-off',
+      pending: 'mdi-bell',
+      armed_home: 'mdi-bell-plus',
+      armed_away: 'mdi-bell',
+      triggered: 'mdi-bell-ring'
+   },
+   states: {
+      disarmed: 'Disarmed',
+      pending: 'Pending',
+      armed_home: 'Armed home',
+      armed_away: 'Armed away',
+      triggered: 'Triggered'
+   }
+},
+/*
+```
+                  
                   {
                      position: [0, 1], // [x, y]
                      width: 1,
@@ -264,39 +340,6 @@ Page object can have the following fields:
                      title: 'Custom switch',
                      icons: {'off': 'mdi-volume-off', 'on': 'mdi-volume-high'}
                   },
-/*
-```                  
-                  
-#### ALARM
-
-![ALARM](images/tile-screenshots/ALARM.png)
-
-```js 
-*/
-{
-   position: [0, 3],
-   type: TYPES.ALARM,
-   title: 'Alarm',
-   //id: "alarm_control_panel.home_alarm",
-   id: id: { state: 'disarmed' }, // replace it with real string id
-   icons: {
-      disarmed: 'mdi-bell-off',
-      pending: 'mdi-bell',
-      armed_home: 'mdi-bell-plus',
-      armed_away: 'mdi-bell',
-      triggered: 'mdi-bell-ring'
-   },
-   states: {
-      disarmed: 'Disarmed',
-      pending: 'Pending',
-      armed_home: 'Armed home',
-      armed_away: 'Armed away',
-      triggered: 'Triggered'
-   }
-},
-/*
-```
-
                ],
             },
 

--- a/config.example.js
+++ b/config.example.js
@@ -1,33 +1,122 @@
-/*
- This is an example configuration file.
+/*<!-- vim: syntax=Markdown -->
+# Example configuration file
+This is a documented example configuration file.
 
- COPY OR RENAME THIS FILE TO config.js.
+**COPY OR RENAME THIS FILE TO `config.js` to get a starting point for your configuration.**
 
- Make sure you use real IDs from your HA entities.
+Make sure you use real IDs from your HA entities.
+
+# Table of contents
+1. [General options](#general-options-back-to-toc)
+2. [Structure of a TileBoard layout](#structure-of-a-tileboard-layout-back-to-toc)
+
+## General options <sup>[back to toc](#table-of-contents)</sup>
+
+
+`config.js` will initialize a global `CONFIG` object with the following fields to influence general behavior:
+
+```js 
 */
-
-
 var CONFIG = {
-   customTheme: null, // CUSTOM_THEMES.TRANSPARENT, CUSTOM_THEMES.MATERIAL, CUSTOM_THEMES.MOBILE, CUSTOM_THEMES.COMPACT, CUSTOM_THEMES.HOMEKIT, CUSTOM_THEMES.WINPHONE, CUSTOM_THEMES.WIN95
-   transition: TRANSITIONS.ANIMATED_GPU, //ANIMATED or SIMPLE (better perfomance)
-   entitySize: ENTITY_SIZES.NORMAL, //SMALL, BIG are available
-   tileSize: 150,
-   tileMargin: 6,
+/*
+```
+
+### Connection settings <sup>[back to toc](#table-of-contents)</sup>
+
+```js
+/*
    serverUrl: 'http://' + location.hostname + ':8123',
    wsUrl: 'ws://' + location.hostname + ':8123/api/websocket',
+   debug: false, // Prints entities and state change info to the console.
+   pingConnection: true, //ping connection to prevent silent disconnections
+/*
+```
+> :warning: **Security advice**:
+> The following authentication info will be readable in the source code. So, make sure you are either not using it, or, your TileBoard is not exposed to untrusted persons (e.g. on the internet)!
+```js
+/*
    authToken: null, // optional long-lived token (CAUTION: only if TileBoard is not exposed to the internet)
    //googleApiKey: "XXXXXXXXXX", // Required if you are using Google Maps for device tracker
    //mapboxToken: "XXXXXXXXXX", // Required if you are using Mapbox for device tracker
-   debug: false, // Prints entities and state change info to the console.
-   pingConnection: true, //ping connection to prevent silent disconnections
+/*
+```
 
-   // next fields are optional
-   events: [],
+### Basic appearance settings <sup>[back to toc](#table-of-contents)</sup>
+
+```js
+/*
    timeFormat: 24,
    menuPosition: MENU_POSITIONS.LEFT, // or BOTTOM
    hideScrollbar: false, // horizontal scrollbar
    groupsAlign: GROUP_ALIGNS.HORIZONTALLY, // or VERTICALLY
+
+   /* customTheme: Specify a custom theme for your dashboard
+    * Valid options: null, CUSTOM_THEMES.TRANSPARENT, CUSTOM_THEMES.MATERIAL, CUSTOM_THEMES.MOBILE, CUSTOM_THEMES.COMPACT, CUSTOM_THEMES.HOMEKIT, CUSTOM_THEMES.WINPHONE, CUSTOM_THEMES.WIN95 or a custom theme you have created
+    * Default: null. Array supported
+    */
+   customTheme: null,
+   
+   /* transition: The transition effect used between Pages
+    * Valid options: TRANSITIONS.ANIMATED, TRANSITIONS.ANIMATED_GPU, TRANSITIONS.SIMPLE
+    */
+   transition: TRANSITIONS.ANIMATED_GPU,
+   
+   /* tileSize: The default size (in pixels) of a tile */
+   tileSize: 150,
+   /* tileMargin: The default margin (in pixels) between tiles */
+   tileMargin: 6,
+   /* entitySize: Size of each tile's content
+    * valid option: ENTITY_SIZES.NORMAL, ENTITY_SIZES.SMALL, ENTITY_SIZES.BIG
+    */
+   entitySize: ENTITY_SIZES.NORMAL,
+   
+/*
+```
+
+### Global interactive elements <sup>[back to toc](#table-of-contents)</sup>
+
+```js
+/*
+   /* events: A list of events. See documentation on Events below */
+   events: [],
    onReady: function () {},
+/*
+```
+
+## Structure of a TileBoard layout <sup>[back to toc](#table-of-contents)</sup>
+
+The following fields are used to influence the actual appearance of your TileBoard:
+
+```js 
+*/
+
+   /* pages: A list of page objects. See documentation on Pages below */
+   pages: [],
+   /* screensaver: A digital picture frame with a clock. Appears when    
+    * the dashboard has been idle
+    * https://github.com/resoai/TileBoard/wiki/Screensaver-configuration
+    * (optional)
+    */
+   screensaver: { },
+   
+   /* header: object of header. Will be applied globally
+    * https://github.com/resoai/TileBoard/wiki/Header-configuration
+    * (optional)
+    */
+   header: DEFAULT_HEADER,
+
+/*
+```
+
+### Pages
+
+Page object can have the following fields:
+
+```js 
+*/
+
+
+
 
    header: { // https://github.com/resoai/TileBoard/wiki/Header-configuration
       styles: {


### PR DESCRIPTION
I started to play around with unified examples and I believe this is as far as I can get. It's far from complete, but I tried to line out the general structure. The code fences and block comments are not pretty, but it's the least invasive I could think of.

What do you think? Maybe you have ideas how to generate a markdown view for Github display using rollup? 

I thought, I'd open this draft PR as a discussion place...

Here's the rendered file: https://github.com/akloeckner/TileBoard/blob/test/unify-examples/config.example.js