### PR TITLE
refactor: move default actions to TILE_DEFAULTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,13 +281,17 @@ Tile Object. [Click here for some real-life examples](TILE_EXAMPLES.md)
   /* action: Define a custom action on click
    * You can override the default action for any tile type.
    * This function will be evaluated, when the user clicks the tile.
+   * Set this to false to disable the default action.
    */
   action: function(item, entity) {return this.$scope.openPopupIframe(item, entity);}
+  action: false,
   /* secondaryAction: Define a custom secondary action (on long press)
    * You can override the default secondary action for any tile type.
    * This function will be evaluated, when the user long-presses the tile.
+   * Set this to false to disable the default secondary action.
    */
   secondaryAction: function(item, entity) {return this.$scope.openPopupIframe(item, entity);}
+  secondaryAction: false,
 
   /* hidden: hide tile (optional)
    * can be boolean or function that return boolean

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -482,6 +482,9 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
       if ($scope.selectOpened(item)) {
          item._classes.push('-top-entity');
       }
+      if (item.action) {
+         item._classes.push('-clickable');
+      }
 
       return item._classes;
    };

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -80,65 +80,28 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
    window.addEventListener('resize', debounce(innerHeightToCSS, 250));
 
    $scope.entityClick = function (page, item, entity) {
-      if (typeof item.action === 'function') {
-         return callFunction(item.action, [item, entity]);
+      if (item.action === false) {
+         return null;
       }
 
-      switch (item.type) {
-         case TYPES.SWITCH:
-         case TYPES.LIGHT:
-         case TYPES.FAN:
-         case TYPES.INPUT_BOOLEAN: return $scope.toggleSwitch(item, entity);
-
-         case TYPES.LOCK: return $scope.toggleLock(item, entity);
-         case TYPES.COVER_TOGGLE: return $scope.toggleCover(item, entity);
-
-         case TYPES.VACUUM: return $scope.toggleVacuum(item, entity);
-
-         case TYPES.AUTOMATION: return $scope.triggerAutomation(item, entity);
-
-         case TYPES.SCRIPT: return $scope.callScript(item, entity);
-
-         case TYPES.INPUT_SELECT: return $scope.toggleSelect(item, entity);
-
-         case TYPES.CAMERA:
-         case TYPES.CAMERA_STREAM:
-         case TYPES.CAMERA_THUMBNAIL: return $scope.openCamera(item, entity);
-
-         case TYPES.SCENE: return $scope.callScene(item, entity);
-
-         case TYPES.DOOR_ENTRY: return $scope.openDoorEntry(item, entity);
-
-         case TYPES.ALARM: return $scope.openAlarm(item, entity);
-
-         case TYPES.DIMMER_SWITCH: return $scope.dimmerToggle(item, entity);
-
-         case TYPES.POPUP_IFRAME: return $scope.openPopupIframe(item, entity);
-
-         case TYPES.POPUP: return $scope.openPopup(item, entity, item.popup);
-
-         case TYPES.INPUT_DATETIME: return $scope.openDatetime(item, entity);
+      if (typeof item.action === 'function') {
+         return callFunction(item.action, [item, entity]);
       }
    };
 
    $scope.entityLongPress = function ($event, page, item, entity) {
       addGhost([$event.changedPointers[0].clientX, $event.changedPointers[0].clientY]);
 
+      if (item.secondaryAction === false) {
+         return null;
+      }
+
       if (typeof item.secondaryAction === 'function') {
          return callFunction(item.secondaryAction, [item, entity]);
       }
 
-      if (item.history) {
+      if (item.history || entity && entity.entity_id) {
          return $scope.openPopupHistory(item, entity);
-      }
-
-      switch (item.type) {
-         case TYPES.LIGHT: return $scope.openLightSliders(item, entity);
-         default: {
-            if (entity && entity.entity_id) {
-               return $scope.openPopupHistory(item, entity);
-            }
-         }
       }
    };
 

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -81,7 +81,7 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
 
    $scope.entityClick = function (page, item, entity) {
       if (item.action === false) {
-         return null;
+         return;
       }
 
       if (typeof item.action === 'function') {
@@ -93,7 +93,7 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
       addGhost([$event.changedPointers[0].clientX, $event.changedPointers[0].clientY]);
 
       if (item.secondaryAction === false) {
-         return null;
+         return;
       }
 
       if (typeof item.secondaryAction === 'function') {

--- a/scripts/globals/constants.js
+++ b/scripts/globals/constants.js
@@ -370,7 +370,7 @@ export const TILE_DEFAULTS = {
    },
    [TYPES.POPUP]: {
       action (item, entity) {
-         return this.$scope.openPopup(item, entity);
+         return this.$scope.openPopup(item, entity, item.popup);
       },
    },
    [TYPES.POPUP_IFRAME]: {

--- a/scripts/globals/constants.js
+++ b/scripts/globals/constants.js
@@ -278,6 +278,51 @@ export const DEFAULT_VOLUME_SLIDER_OPTIONS = {
 };
 
 export const TILE_DEFAULTS = {
+   [TYPES.ALARM]: {
+      action (item, entity) {
+         return this.$scope.openAlarm(item, entity);
+      },
+   },
+   [TYPES.AUTOMATION]: {
+      action (item, entity) {
+         return this.$scope.triggerAutomation(item, entity);
+      },
+   },
+   [TYPES.CAMERA]: {
+      action (item, entity) {
+         return this.$scope.openCamera(item, entity);
+      },
+   },
+   [TYPES.CAMERA_STREAM]: {
+      action (item, entity) {
+         return this.$scope.openCamera(item, entity);
+      },
+   },
+   [TYPES.CAMERA_THUMBNAIL]: {
+      action (item, entity) {
+         return this.$scope.openCamera(item, entity);
+      },
+   },
+   [TYPES.COVER_TOGGLE]: {
+      action (item, entity) {
+         return this.$scope.toggleCover(item, entity);
+      },
+   },
+   [TYPES.DIMMER_SWITCH]: {
+      action (item, entity) {
+         return this.$scope.dimmerToggle(item, entity);
+      },
+   },
+   [TYPES.DOOR_ENTRY]: {
+      action (item, entity) {
+         return this.$scope.openDoorEntry(item, entity);
+      },
+   },
+   [TYPES.FAN]: {
+      action (item, entity) {
+         return this.$scope.toggleSwitch(item, entity);
+      },
+   },
    [TYPES.GAUGE]: {
       settings: {
          backgroundColor: 'rgba(0, 0, 0, 0.1)',
@@ -294,7 +339,63 @@ export const TILE_DEFAULTS = {
          thresholds: {},
       },
    },
+   [TYPES.INPUT_BOOLEAN]: {
+      action (item, entity) {
+         return this.$scope.toggleSwitch(item, entity);
+      },
+   },
+   [TYPES.INPUT_DATETIME]: {
+      action (item, entity) {
+         return this.$scope.openDatetime(item, entity);
+      },
+   },
+   [TYPES.INPUT_SELECT]: {
+      action (item, entity) {
+         return this.$scope.toggleSelect(item, entity);
+      },
+   },
    [TYPES.LIGHT]: {
       colorpicker: (item, entity) => supportsFeature(FEATURES.LIGHT.COLOR, entity),
+      action (item, entity) {
+         return this.$scope.toggleSwitch(item, entity);
+      },
+      secondaryAction (item, entity) {
+         return this.$scope.openLightSliders(item, entity);
+      },
+   },
+   [TYPES.LOCK]: {
+      action (item, entity) {
+         return this.$scope.toggleLock(item, entity);
+      },
+   },
+   [TYPES.POPUP]: {
+      action (item, entity) {
+         return this.$scope.openPopup(item, entity);
+      },
+   },
+   [TYPES.POPUP_IFRAME]: {
+      action (item, entity) {
+         return this.$scope.openPopupIframe(item, entity);
+      },
+   },
+   [TYPES.SCENE]: {
+      action (item, entity) {
+         return this.$scope.callScene(item, entity);
+      },
+   },
+   [TYPES.SCRIPT]: {
+      action (item, entity) {
+         return this.$scope.callScript(item, entity);
+      },
+   },
+   [TYPES.SWITCH]: {
+      action (item, entity) {
+         return this.$scope.toggleSwitch(item, entity);
+      },
+   },
+   [TYPES.VACUUM]: {
+      action (item, entity) {
+         return this.$scope.toggleVacuum(item, entity);
+      },
    },
 };

--- a/styles/main.less
+++ b/styles/main.less
@@ -581,36 +581,23 @@ body {
 
    &-clickable {
       display: none;
+      left: 5px;
+      top: 5px;
+      height: 6px;
+      width: 6px;
+      border-left: 2px solid rgba(255,255,255,.8);
+      border-top: 2px solid rgba(255,255,255,.8);
+      opacity: 0.5;
+      position: absolute;
+      z-index: 2;
    }
 
-   &.-switch,
-   &.-lock,
-   &.-cover_toggle,
-   &.-vacuum,
-   &.-fan,
-   &.-custom,
-   &.-light,
-   &.-script,
-   &.-automation,
-   &.-input_boolean,
-   &.-input_select,
-   &.-camera,
-   &.-camera_thumbnail,
-   &.-camera_stream,
-   &.-alarm,
-   &.-door_entry,
-   &.-popup_iframe,
-   &.-popup,
-   &.-input_datetime,
-   &.-dimmer_switch,
-   &.-scene {
-      cursor: pointer;
+   &:active &-clickable {
+      opacity: 1;
+   }
 
-      /*&:hover {
-         margin-top: -2px;
-         margin-left: -2px;
-         border: 2px solid rgba(200,200,200,.6);
-      }*/
+   &.-clickable {
+      cursor: pointer;
 
       &:active {
          margin-top: -2px;
@@ -620,20 +607,7 @@ body {
 
       .item-clickable {
          display: block;
-         left: 5px;
-         top: 5px;
-         height: 6px;
-         width: 6px;
-         border-left: 2px solid rgba(255,255,255,.8);
-         border-top: 2px solid rgba(255,255,255,.8);
-         opacity: 0.5;
-         position: absolute;
-         z-index: 2;
       }
-   }
-
-   &:active .item-clickable {
-      opacity: 1;
    }
 
    &.-device_tracker {


### PR DESCRIPTION
also introduce the option to disable actions by setting `action: false` or `secondaryAction: false`
also show "clickable" tick not for fixed tile types, but for tiles with `action` defined