### PR TITLE
feat: i18n

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "angular": "^1.8.2",
     "angular-chart.js": "^1.1.1",
     "angular-hammer": "^2.2.0",
+    "angular-i18n": "^1.8.2",
     "angular-moment": "^1.3.0",
     "angularjs-gauge": "^2.2.0",
     "chart.js": "^2.9.4",

--- a/scripts/globals/utils.js
+++ b/scripts/globals/utils.js
@@ -92,3 +92,12 @@ export function supportsFeature (feature, entity) {
    return 'supported_features' in entity.attributes
       && (entity.attributes.supported_features & feature) !== 0;
 }
+
+export function loadScript (url) {
+   const xhttp = new XMLHttpRequest();
+   const script = document.createElement('script');
+   xhttp.open('GET', url + '?c=' + Date.now(), false);
+   xhttp.send();
+   script.text = xhttp.responseText;
+   document.head.appendChild(script).parentNode.removeChild(script);
+}

--- a/scripts/globals/utils.js
+++ b/scripts/globals/utils.js
@@ -3,6 +3,8 @@ import moment from 'moment';
 
 export { moment };
 
+export * from '../i18n';
+
 export const mergeObjects = angular.merge;
 
 export const leadZero = function (num) {

--- a/scripts/globals/utils.js
+++ b/scripts/globals/utils.js
@@ -1,6 +1,8 @@
 import angular from 'angular';
 import moment from 'moment';
 
+export { moment };
+
 export const mergeObjects = angular.merge;
 
 export const leadZero = function (num) {

--- a/scripts/i18n/de-de.js
+++ b/scripts/i18n/de-de.js
@@ -1,0 +1,5 @@
+import 'angular-i18n/de-de';
+import 'moment/locale/de';
+
+import { extractNgLocale } from './utils.js';
+extractNgLocale();

--- a/scripts/i18n/en-us.js
+++ b/scripts/i18n/en-us.js
@@ -1,0 +1,5 @@
+import 'angular-i18n/en-us';
+import 'moment/locale/en-gb';
+
+import { extractNgLocale } from './utils.js';
+extractNgLocale();

--- a/scripts/i18n/index.js
+++ b/scripts/i18n/index.js
@@ -1,0 +1,9 @@
+// import individual locale bundles
+import './de-de';
+
+// import default locale last
+import './en-us';
+
+// export setLocale to be used by the actual app
+import { setLocale } from './utils';
+export { setLocale };

--- a/scripts/i18n/utils.js
+++ b/scripts/i18n/utils.js
@@ -1,0 +1,31 @@
+// object holding all locale setups
+const _locales = {};
+
+// emulate $provide.value()
+const mockProvide = {
+   value (key, val) {
+      mockProvide[key] = val;
+   },
+};
+
+// export the current ngLocale setup
+export function extractNgLocale () {
+   const currentModule = angular.module('ngLocale');
+   const configFunction = currentModule._configBlocks[0][2][0][1];
+
+   configFunction(mockProvide);
+   _locales[mockProvide.$locale.id] = {
+      name: currentModule.name,
+      requires: currentModule.requires,
+      configFunction: configFunction,
+      $locale: mockProvide.$locale,
+   };
+}
+
+// actually set the locale
+import moment from 'moment';
+import angular from 'angular';
+export function setLocale (id) {
+   angular.module(_locales[id].name, _locales[id].requires, _locales[id].configFunction);
+   moment.locale(id);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1094,6 +1094,11 @@ angular-hammer@^2.2.0:
     angular ">=1.2.0"
     hammerjs ">=2.0.0"
 
+angular-i18n@^1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/angular-i18n/-/angular-i18n-1.8.2.tgz#eeeaef6e065d60759c03986397b37a87cbcbea33"
+  integrity sha512-IVXiWS0fWLnDPTy5z/iO/mVATE3/Eyj0aHEUrhSro8Dxtsv0iw6RLBATkawl4z7AZPX3eN6pqScd5dg56m0dpA==
+
 angular-moment@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/angular-moment/-/angular-moment-1.3.0.tgz#f501f66b6fcc832d8d36f8905cc7a93123ab2af0"


### PR DESCRIPTION
This adds support for internationalization. The following will work in `config.js` (assuming that we're living off the `build` directory):
```
loadScript('../node_modules/angular-i18n/angular-locale_de-de.js');
loadScript('../node_modules/moment/locale/de.js');
```

See also: https://github.com/resoai/TileBoard/pull/521#discussion_r520941850

I'd now like to bundle the localization files using rollup, as this will allow us to catch any updates. But I have no clue, how this should be done... Can you give a hint on that, please? @rchl 

fixes #344
fixes #327 