### PR TITLE
chore: enable camelcase eslint rule

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -14,6 +14,9 @@ rules:
   arrow-spacing: error
   block-scoped-var: error
   brace-style: error
+  camelcase:
+    - error
+    - properties: never
   comma-dangle:
     - error
     - always-multiline

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "rollup --config --environment PRODUCTION",
     "build:watch": "rollup --config --environment PRODUCTION --watch",
     "lint": "eslint rollup.config.js scripts",
-    "fix": "eslint rollup.config.js scripts --fix",
+    "fix": "eslint --fix rollup.config.js scripts",
     "release": "standard-version"
   },
   "standard-version": {

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -166,17 +166,17 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
    };
 
    $scope.getCameraEntityFullscreen = function (item) {
-      let entity_id = getItemFieldValue('fullscreen.id', item, {});
+      let entityId = getItemFieldValue('fullscreen.id', item, {});
 
-      if (entity_id === null) {
-         entity_id = item.id;
+      if (entityId === null) {
+         entityId = item.id;
       }
 
-      if (typeof entity_id === 'object') {
-         return entity_id;
+      if (typeof entityId === 'object') {
+         return entityId;
       }
 
-      return $scope.states[entity_id];
+      return $scope.states[entityId];
    };
 
    $scope.showPage = function (page) {


### PR DESCRIPTION
The rule is disabled for properties as the HA API requires to pass
non-camelcase keys sometimes.