### PR TITLE
fix(CLIMATE): fix climate state toggle not showing up in hvac mode

### DIFF
--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -1228,7 +1228,7 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
    };
 
    $scope.getClimateCurrentOption = function (item, entity) {
-      return item.useHvacMode ? entity.attributes.hvac_mode : entity.attributes.preset_mode;
+      return item.useHvacMode ? entity.state : entity.attributes.preset_mode;
    };
 
    $scope.setClimateOption = function ($event, item, entity, option) {

--- a/scripts/globals/constants.js
+++ b/scripts/globals/constants.js
@@ -303,6 +303,11 @@ export const TILE_DEFAULTS = {
          return this.$scope.openCamera(item, entity);
       },
    },
+   [TYPES.CLIMATE]: {
+      subtitle (item, entity) {
+         return item.useHvacMode ? entity.attributes.hvac_action : undefined;
+      },
+   },
    [TYPES.COVER_TOGGLE]: {
       action (item, entity) {
          return this.$scope.toggleCover(item, entity);


### PR DESCRIPTION
Also, show "hvac_action" attribute by default in the subtitle as, when
available, it shows the current state of the climate device which should
be quite useful.

Resolves #526