### PR TITLE
fix(CAMERA_STREAM): support non-HLS-capable devices

### DIFF
--- a/scripts/directives.js
+++ b/scripts/directives.js
@@ -227,22 +227,30 @@ App.directive('cameraStream', function (Api) {
             el.style.height = '100%';
             el.muted = 'muted';
 
-            const len = $scope.item.bufferLength || 5;
+            if (Hls.isSupported()) {
+               const len = $scope.item.bufferLength || 5;
 
-            const config = {
-               maxBufferLength: len,
-               maxMaxBufferLength: len,
-            };
+               const config = {
+                  maxBufferLength: len,
+                  maxMaxBufferLength: len,
+               };
 
-            if (hls) {
-               hls.destroy();
+               if (hls) {
+                  hls.destroy();
+               }
+               hls = new Hls(config);
+               hls.loadSource(url);
+               hls.attachMedia(el);
+               hls.on(Hls.Events.MANIFEST_PARSED, function () {
+                  el.play();
+               });
+            } else {
+               el.src = url;
+               el.setAttribute('playsinline', 'playsinline');
+               el.addEventListener('loadedmetadata', function () {
+                  el.play();
+               });
             }
-            hls = new Hls(config);
-            hls.loadSource(url);
-            hls.attachMedia(el);
-            hls.on(Hls.Events.MANIFEST_PARSED, function () {
-               el.play();
-            });
 
             if (current) {
                $el[0].removeChild(current);


### PR DESCRIPTION
Non HLS compatible devices, like old generation iPads, could try to "stream" video using internal browser capabilities, like Safari in iOS.

Camera Stream not working on legacy iPad:
![image](https://user-images.githubusercontent.com/3169762/99919245-3c442380-2cea-11eb-9e79-f3a944521d90.png)

Using `video` tag attributes directly works:
![image](https://user-images.githubusercontent.com/3169762/99919359-e623b000-2cea-11eb-8484-00cdca4920d5.png)

Example config:
```js
{
  position: [0, 0],
  width: 3,
  height: 2,
  bgSize: "cover",
  state: false,
  type: TYPES.CAMERA_THUMBNAIL,
  refresh: 5000,
  id: "camera.backyard",
  fullscreen: {
    type: TYPES.CAMERA_STREAM,
    noHls: true,
    objFit: "contain",
    id: "camera.backyard",
    bufferLength: 5,
  },
}
```