### PR TITLE
fix(CAMERA_STREAM): pause stream when screensaver active or page changed

### DIFF
--- a/index.html.ejs
+++ b/index.html.ejs
@@ -76,8 +76,7 @@
             </div>
 
             <div ng-if="activeCamera.fullscreen.type === TYPES.CAMERA_STREAM">
-               <camera-stream item="activeCamera.fullscreen" entity="entity"
-                              freezed="false"></camera-stream>
+               <camera-stream item="activeCamera.fullscreen" entity="entity" freezed="screensaverShown"></camera-stream>
             </div>
          </div>
       </div>

--- a/index.html.ejs
+++ b/index.html.ejs
@@ -66,17 +66,15 @@
 
          <div class="camera-popup--camera">
             <div ng-if="activeCamera.fullscreen.type === TYPES.CAMERA">
-               <camera item="activeCamera.fullscreen" entity="entity"
-                       freezed="false"></camera>
+               <camera item="activeCamera.fullscreen" entity="entity" frozen="false"></camera>
             </div>
 
             <div ng-if="activeCamera.fullscreen.type === TYPES.CAMERA_THUMBNAIL">
-               <camera-thumbnail item="activeCamera.fullscreen" entity="entity"
-                                 freezed="false"></camera-thumbnail>
+               <camera-thumbnail item="activeCamera.fullscreen" entity="entity" frozen="false"></camera-thumbnail>
             </div>
 
             <div ng-if="activeCamera.fullscreen.type === TYPES.CAMERA_STREAM">
-               <camera-stream item="activeCamera.fullscreen" entity="entity" freezed="screensaverShown"></camera-stream>
+               <camera-stream item="activeCamera.fullscreen" entity="entity" frozen="screensaverShown"></camera-stream>
             </div>
          </div>
       </div>
@@ -697,7 +695,7 @@
            class="item-entity-container -below">
          <div class="item-camera">
             <camera item="item" entity="entity"
-                    freezed="(!isPopupActive(page) && !isPageActive(page)) || activeCamera || screensaverShown"></camera>
+                    frozen="(!isPopupActive(page) && !isPageActive(page)) || activeCamera || screensaverShown"></camera>
          </div>
       </div>
 
@@ -705,7 +703,7 @@
            class="item-entity-container -below">
          <div class="item-camera">
             <camera-thumbnail item="item" entity="entity"
-                              freezed="(!isPopupActive(page) && !isPageActive(page)) || activeCamera || screensaverShown"></camera-thumbnail>
+                              frozen="(!isPopupActive(page) && !isPageActive(page)) || activeCamera || screensaverShown"></camera-thumbnail>
          </div>
       </div>
 
@@ -713,7 +711,7 @@
            class="item-entity-container -below">
          <div class="item-camera">
             <camera-stream item="item" entity="entity"
-                           freezed="(!isPopupActive(page) && !isPageActive(page)) || activeCamera || screensaverShown"></camera-stream>
+                           frozen="(!isPopupActive(page) && !isPageActive(page)) || activeCamera || screensaverShown"></camera-stream>
          </div>
       </div>
 

--- a/scripts/directives.js
+++ b/scripts/directives.js
@@ -20,7 +20,7 @@ App.directive('camera', function () {
       scope: {
          item: '=item',
          entity: '=entity',
-         freezed: '=freezed',
+         frozen: '=frozen',
       },
       link: function ($scope, $el, attrs) {
          let $i = 0;
@@ -73,7 +73,7 @@ App.directive('camera', function () {
                return;
             }
 
-            if ($i > 1 && $scope.freezed) {
+            if ($i > 1 && $scope.frozen) {
                return;
             }
 
@@ -125,7 +125,7 @@ App.directive('cameraThumbnail', function (Api) {
       scope: {
          item: '=item',
          entity: '=entity',
-         freezed: '=freezed',
+         frozen: '=frozen',
       },
       link: function ($scope, $el, attrs) {
          let refresh = 'refresh' in $scope.item ? $scope.item.refresh : 2000;
@@ -166,7 +166,7 @@ App.directive('cameraThumbnail', function (Api) {
                return;
             }
 
-            if (lastUpdate && $scope.freezed) {
+            if (lastUpdate && $scope.frozen) {
                return;
             }
 
@@ -214,11 +214,11 @@ App.directive('cameraStream', function (Api, $timeout) {
       scope: {
          item: '=item',
          entity: '=entity',
-         freezed: '=freezed',
+         frozen: '=frozen',
       },
       link: function ($scope, $el, attrs) {
          // Time after which the stream will be stopped entirely (media element will be detached)
-         // after the playback was paused due to freezed=true.
+         // after the playback was paused due to frozen=true.
          const SUSPEND_TIMEOUT_MS = 5000;
          let suspendPromise = null;
          /** @type {HTMLMediaElement | null} */
@@ -226,9 +226,9 @@ App.directive('cameraStream', function (Api, $timeout) {
          /** @type {Hls | null} */
          let hls = null;
 
-         $scope.$watch('freezed', freezed => {
+         $scope.$watch('frozen', frozen => {
             if (current) {
-               if (freezed) {
+               if (frozen) {
                   onFreezed();
                } else {
                   onUnfreezed();


### PR DESCRIPTION
Implemented in a way where the playback is stopped when "freezed" (should be "frozen") is `true` and after 5s, if "freezed" doesn't become `false`, the stream is stopped completely.

The stream playing in a popup is only stopped on screensaver activation (as pages can't be changed in that case), while the stream tiles are stopped on screensaver and page change.

Resolves #541