### PR TITLE
chore(ci): update version of the release action

### DIFF
--- a/.github/workflows/on_release.yaml
+++ b/.github/workflows/on_release.yaml
@@ -22,7 +22,7 @@ jobs:
           pushd build
           zip -qr "../TileBoard.zip" .
 
-      - uses: marvinpinto/action-automatic-releases@v1.1.0
+      - uses: marvinpinto/action-automatic-releases@v1
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: false


### PR DESCRIPTION
We still need to wait for the new version of `marvinpinto/action-automatic-releases` being released but this prepares us to use the new version once it released. It can wait here until the dependency is updated.