### PR TITLE
fix(POPUP): merge tile defaults when passing newly created tile object

### DIFF
--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -1,6 +1,6 @@
 import angular from 'angular';
 import Hammer from 'hammerjs';
-import { mergeConfigDefaults, mergeTileConfigs } from './main-utilities';
+import { mergeConfigDefaults, mergeTileConfigs, mergeTileDefaults } from './main-utilities';
 import { App } from '../app';
 import { TYPES, FEATURES, HEADER_ITEMS, MENU_POSITIONS, GROUP_ALIGNS, TRANSITIONS, MAPBOX_MAP, YANDEX_MAP, DEFAULT_SLIDER_OPTIONS, DEFAULT_LIGHT_SLIDER_OPTIONS, DEFAULT_VOLUME_SLIDER_OPTIONS, DEFAULT_POPUP_HISTORY, DEFAULT_POPUP_IFRAME, DEFAULT_POPUP_DOOR_ENTRY } from '../globals/constants';
 import { debounce, leadZero, supportsFeature, toAbsoluteServerURL } from '../globals/utils';
@@ -1396,6 +1396,8 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
    };
 
    $scope.openPopup = function (item, entity, layout) {
+      item = mergeTileDefaults(item);
+
       if ($scope.popupTimeout) {
          clearTimeout($scope.popupTimeout);
          $scope.popupTimeout = null;


### PR DESCRIPTION
We've overlooked the fact that user can pass a newly created tile object
to $scope.showPopup() in which case the tile defaults were not merged.

Explicitly merge defaults from the showPopup() call but avoid doing it
multiple times for tiles that have already had defaults merged by
checking a special cache key.

Fixes #553