### PR TITLE
fix: use polyfill for URLSearchParams

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "chart.js": "^2.9.4",
     "hls.js": "^0.14.16",
     "lodash.mergewith": "^4.6.2",
-    "node-sass": "^5.0.0"
+    "node-sass": "^5.0.0",
+    "url-search-params-polyfill": "^8.1.0"
   },
   "resolutions": {
     "chart.js": "2.9.4"

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -8,6 +8,7 @@ import './controllers/noty';
 import './controllers/screensaver';
 import '../styles/all.less';
 import '@mdi/font/scss/materialdesignicons.scss';
+import 'url-search-params-polyfill';
 
 function onConfigLoadOrError (error) {
    if (error) {
@@ -24,8 +25,7 @@ Please make sure that it defines a CONFIG variable with proper configuration.`);
    window.window.initApp();
 }
 
-const url = new URL(document.location.href);
-const configName = url.searchParams.get('config') || 'config';
+const configName = new URLSearchParams(document.location.search).get('config') || 'config';
 
 const script = document.createElement('script');
 script.src = `./${configName}.js?r=${Date.now()}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6296,6 +6296,11 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
+url-search-params-polyfill@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/url-search-params-polyfill/-/url-search-params-polyfill-8.1.0.tgz#5c15b69687165bfd4f6c7d8a161d70d85385885b"
+  integrity sha512-MRG3vzXyG20BJ2fox50/9ZRoe+2h3RM7DIudVD2u/GY9MtayO1Dkrna76IUOak+uoUPVWbyR0pHCzxctP/eDYQ==
+
 url-toolkit@^2.1.6:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/url-toolkit/-/url-toolkit-2.2.0.tgz#9a57b89f315d4b7dc340e150bcfa548ddf5f5ce9"


### PR DESCRIPTION
since it is not available on iOS 9.3.5 (i.e. old iPads e.g.)

see #530, @anthony2856