### PR TITLE
fix: update history tile's start date on state change

### DIFF
--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -1455,7 +1455,7 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
       }
 
       const day = 24 * 60 * 60 * 1000;
-      let startDate = new Date(Date.now() - ($scope.itemField('offset', config, entity) || day)).toISOString();
+      const startDate = new Date(Date.now() - ($scope.itemField('offset', config, entity) || day)).toISOString();
 
       Api.getHistory(startDate, entityId)
          .then(function (data) {
@@ -1570,14 +1570,14 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
             // Delete old data
             const deleteOldData = function () {
                // Update start date
-               startDate = new Date(Date.now() - ($scope.itemField('offset', config, entity) || day)).toISOString();
+               const newStartDate = new Date(Date.now() - ($scope.itemField('offset', config, entity) || day));
 
                // Clean data older than new start date (done on all datasets)
                for (let dataIndex = 0; dataIndex < historyObject.data.length; dataIndex++) {
                   let cleaningFinished = false;
                   while (!cleaningFinished && historyObject.data[dataIndex].length > 0) {
                      const firstHistoryDate = historyObject.data[dataIndex][0].x;
-                     if (Date.parse(firstHistoryDate) < Date.parse(startDate)) {
+                     if (firstHistoryDate < newStartDate) {
                         historyObject.data[dataIndex].shift();
                      } else {
                         cleaningFinished = true;

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -1455,7 +1455,7 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
       }
 
       const day = 24 * 60 * 60 * 1000;
-      var startDate = new Date(Date.now() - ($scope.itemField('offset', config, entity) || day)).toISOString();
+      let startDate = new Date(Date.now() - ($scope.itemField('offset', config, entity) || day)).toISOString();
 
       Api.getHistory(startDate, entityId)
          .then(function (data) {
@@ -1568,15 +1568,15 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
             }, $scope.itemField('options', config, entity));
 
             // Delete old data
-            var deleteOldData = function () {
+            const deleteOldData = function () {
                // Update start date
-               startDate = new Date(Date.now() - ($scope.itemField("offset", config, entity) || day)).toISOString();
+               startDate = new Date(Date.now() - ($scope.itemField('offset', config, entity) || day)).toISOString();
 
                // Clean data older than new start date (done on all datasets)
                for (let dataIndex = 0; dataIndex < historyObject.data.length; dataIndex++) {
                   let cleaningFinished = false;
                   while (!cleaningFinished && historyObject.data[dataIndex].length > 0) {
-                     let firstHistoryDate = historyObject.data[dataIndex][0].x;
+                     const firstHistoryDate = historyObject.data[dataIndex][0].x;
                      if (Date.parse(firstHistoryDate) < Date.parse(startDate)) {
                         historyObject.data[dataIndex].shift();
                      } else {

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -1588,27 +1588,27 @@ App.controller('Main', function ($scope, $timeout, $location, Api) {
 
             // Add watchers to update data on the fly
             if (typeof entityId === 'string') {
-               historyObject.watchers.push($scope.$watch(
+               historyObject.watchers.push($scope.$watchCollection(
                   function () {
-                     return $scope.states[entityId].state;
+                     return [ $scope.states[entityId].state, $scope.states[entityId].last_updated ];
                   },
                   function (newValue) {
                      historyObject.data[0].push({
                         x: new Date(),
-                        y: newValue,
+                        y: newValue[0],
                      });
                      deleteOldData();
                   }));
             } else {
                entityId.forEach(function (entityId, index) {
-                  historyObject.watchers.push($scope.$watch(
+                  historyObject.watchers.push($scope.$watchCollection(
                      function () {
-                        return $scope.states[entityId].state;
+                        return [ $scope.states[entityId].state, $scope.states[entityId].last_updated ];
                      },
                      function (newValue) {
                         historyObject.data[index].push({
                            x: new Date(),
-                           y: newValue,
+                           y: newValue[0],
                         });
                         deleteOldData();
                      }));


### PR DESCRIPTION
### Proposed change 1

When a history tile is shown 24/7 on a dashboard, new entries get added, but the initial start date never moves forward.
As a result, data piles up, and the initial requested offset increases constantly. After days/weeks, huge amount of data stored in the dataset can cause issues on the client side.

This small change will constantly update the start date and delete any data that is older than (NOW - OFFSET).

Shown time frame will constantly be moving forward.

### Proposed change 2

In some particular cases, especially when entity states get updated rarely (only a few times a day, or even week), the history tile will no longer show any value after a while. (=> moving time window).

Hassio itself has this issue and a workaround is described here: https://community.home-assistant.io/t/add-force-update-support-to-template-sensor/106901

The workaround consists in updating any entity attribute value. This will cause the entity's last_updated value to be updated.

On the history tile, this is easily fixed by adding entity's last_updated value to the watcher.

Watcher will add new data, when state or last_updated changes...
