### PR TITLE
fix(SLIDER): update value in real-time on change

### DIFF
--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -873,6 +873,20 @@ App.controller('Main', function ($scope, $timeout, $location, Api, tmhDynamicLoc
       return initSliderConf(item, entity, { }, DEFAULT_VOLUME_SLIDER_OPTIONS);
    };
 
+   $scope.getSliderValue = function (item, entity, conf) {
+      let value = conf.value;
+
+      if (item.slider.formatValue) {
+         value = item.slider.formatValue(conf);
+      }
+
+      if (typeof item.filter === 'function') {
+         return callFunction(item.filter, [value, item, entity]);
+      }
+
+      return value;
+   };
+
    $scope.getLightSliderValue = function (slider, conf) {
       if (slider.formatValue) {
          return slider.formatValue(conf);

--- a/scripts/directives/tile.html
+++ b/scripts/directives/tile.html
@@ -304,17 +304,19 @@
       </div>
    </div>
 
-   <div ng-if="item.type === TYPES.SLIDER"
+   <div ng-if="item.type === TYPES.SLIDER && (_c = getSliderConf(item, entity))"
         class="item-entity-container" ng-class="{'-slider-bottom': item.bottom}">
 
       <div class="item-entity">
-         <span ng-bind="entityValue(item, entity)"
+         <!-- <span ng-bind="entityValue(item, entity)"
+               class="item-entity--value"></span> -->
+         <span ng-bind="getSliderValue(item, entity, _c)" 
                class="item-entity--value"></span>
          <span ng-if="(_unit = entityUnit(item, entity))"
                class="item-entity--unit" ng-bind="_unit"></span>
       </div>
 
-      <div class="item-slider" ng-if="(_c = getSliderConf(item, entity))">
+      <div class="item-slider" >
          <input type="range"
                 ng-model="_c.getSetValue"
                 ng-model-options="{ getterSetter: true }"

--- a/scripts/directives/tile.html
+++ b/scripts/directives/tile.html
@@ -308,15 +308,13 @@
         class="item-entity-container" ng-class="{'-slider-bottom': item.bottom}">
 
       <div class="item-entity">
-         <!-- <span ng-bind="entityValue(item, entity)"
-               class="item-entity--value"></span> -->
-         <span ng-bind="getSliderValue(item, entity, _c)" 
+         <span ng-bind="getSliderValue(item, entity, _c)"
                class="item-entity--value"></span>
          <span ng-if="(_unit = entityUnit(item, entity))"
                class="item-entity--unit" ng-bind="_unit"></span>
       </div>
 
-      <div class="item-slider" >
+      <div class="item-slider">
          <input type="range"
                 ng-model="_c.getSetValue"
                 ng-model-options="{ getterSetter: true }"


### PR DESCRIPTION
Makes `Slider Tile` Value more dynamic. 

Currently `Value` for `Slider` Tile not changing during slider movement. It changes only if slider released. With this change `value` become dynamic - it changes during slider move, and doesnt wait slider released, so it means you can see actual slider value. 

Also, it saves ability to use `filter` that applied to `Value`.  

Example:
```
                  {
                     position: [2, 0],
                     height: 2,
                     id: 'light.f1_r2_light_tv_wall',
                     type: TYPES.SLIDER,
                     unit: '%',
                     title: '',
                     state: false,
                     bottom: true,
                     filter: function (value) {
                        var num = parseFloat(value) / 2.55 ;
                        return num && !isNaN(num) ? num.toFixed() : 0;
                     },
                     value: '@attributes.brightness',
                     slider: {
                        max: 255,
                        min: 0,
                        step: 5,
                        field: 'brightness',
                        request: {
                           type: "call_service",
                           domain: "light",
                           service: "turn_on",
                           field: "brightness"
                        },
                     },
                  },
```
