### PR TITLE
fix(SCREENSAVER): fix console errors when using weather tile

### DIFF
--- a/scripts/directives/headerItem.html
+++ b/scripts/directives/headerItem.html
@@ -30,7 +30,7 @@
       <div class="header-weather--summary" ng-if="item.fields.summary">
          <span ng-bind="getWeatherField('summary', item, {})"></span>
       </div>
-      <div class="header-weather--state"  ng-if="!item.fields.summary && (_state = entityState(item, entity))">
+      <div class="header-weather--state"  ng-if="!item.fields.summary && (_state = entityState(item, {}))">
          <span ng-bind="_state"></span>
       </div>
    </div>


### PR DESCRIPTION
The "entity" is undefined in those cases so we have to pass empty
object instead like places above do already.