### PR TITLE
fix(DOOR_ENTRY): non-clickable items when opening popup programmatically

### DIFF
--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -1663,6 +1663,7 @@ App.controller('Main', function ($scope, $timeout, $location, Api, tmhDynamicLoc
    };
 
    $scope.openPopupHistory = function (item, entity) {
+      item = mergeTileDefaults(item);
       const layout = cacheInItem(item, '_popupHistory', () => mergeTileConfigs({}, DEFAULT_POPUP_HISTORY(item, entity), {
          classes: getItemFieldValue('history.classes', item, entity) || [],
          items: [getItemFieldValue('history', item, entity) || {}],
@@ -1671,6 +1672,7 @@ App.controller('Main', function ($scope, $timeout, $location, Api, tmhDynamicLoc
    };
 
    $scope.openPopupIframe = function (item, entity) {
+      item = mergeTileDefaults(item);
       const layout = cacheInItem(item, '_popupIframe', () => mergeTileConfigs({}, DEFAULT_POPUP_IFRAME(item, entity), {
          classes: getItemFieldValue('iframeClasses', item, entity) || [],
          items: [{
@@ -1681,6 +1683,7 @@ App.controller('Main', function ($scope, $timeout, $location, Api, tmhDynamicLoc
    };
 
    $scope.openDoorEntry = function (item, entity) {
+      item = mergeTileDefaults(item);
       const layout = cacheInItem(item, '_popupDoorEntry', () => mergeTileConfigs({}, DEFAULT_POPUP_DOOR_ENTRY(item, entity), {
          items: [
             getItemFieldValue('layout.camera', item, entity) || {},


### PR DESCRIPTION
The item passed to $scope.openDoorEntry() needs to be merged with
defaults so that the layout items get "action" assigned. This is done
from the $scope.openPopup() a bit later but needs to be done before
creating the popup layout. Merging defaults will be a no-op if defaults
are already merged which will be the case when just clicking a DOOR_ENTRY
tile defined in the config.

Also done the same for other types of popups. That's not strictly
necessary right now but could become necessary in the feature if the
defaults are changed.