### PR TITLE
feat: support sensors which are timestamps (like uptime sensor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,8 +328,11 @@ Tile Object. [Click here for some real-life examples](TILE_EXAMPLES.md)
   value: '&sensor.bathroom_temp.state',
   /* unit: Override default unit of measurement */
   unit: 'kWh',
-  /* filter: Function for filtering/formatting the entity value */
-  filter: function (value) {return value},
+  /* filter: Function for filtering/formatting the entity value
+   * Is used by default to format a timestamp as time ago, e.g., for the uptime sensor.
+   */
+  filter: function (value, item, entity) {return Math.round(value);},
+  filter: function (value, item, entity) {return timeAgo(value, true);}, // true = exclude the word 'ago'
   /** type: DEVICE_TRACKER **/
   /* slidesDelay: Delay before slide animation starts (optional) */
   slidesDelay: 2,

--- a/scripts/globals/constants.js
+++ b/scripts/globals/constants.js
@@ -448,6 +448,14 @@ export const TILE_DEFAULTS = {
          return this.$scope.callScript(item, entity);
       },
    },
+   [TYPES.SENSOR]: {
+      filter (value, item, entity) {
+         if (entity?.attributes?.device_class === 'timestamp') {
+            return timeAgo(value, false);
+         }
+         return value;
+      },
+   },
    [TYPES.SWITCH]: {
       action (item, entity) {
          return this.$scope.toggleSwitch(item, entity);

--- a/scripts/globals/utils.js
+++ b/scripts/globals/utils.js
@@ -56,9 +56,9 @@ export const playSound = function (sound) {
    audio.play();
 };
 
-export const timeAgo = function (time, omitAgo) {
+export const timeAgo = function (time, withoutSuffix = false) {
    const momentInTime = moment(new Date(time));
-   return momentInTime.fromNow(omitAgo ?? false);
+   return momentInTime.fromNow(withoutSuffix);
 };
 
 export const debounce = function (func, wait, immediate) {

--- a/scripts/globals/utils.js
+++ b/scripts/globals/utils.js
@@ -54,9 +54,9 @@ export const playSound = function (sound) {
    audio.play();
 };
 
-export const timeAgo = function (time) {
+export const timeAgo = function (time, omitAgo) {
    const momentInTime = moment(new Date(time));
-   return momentInTime.fromNow();
+   return momentInTime.fromNow(omitAgo ?? false);
 };
 
 export const debounce = function (func, wait, immediate) {


### PR DESCRIPTION
* use the default `filter` option for sensors
* parse with `timeAgo` in case we have a timestamp
* include the word `ago`, because timestamps are indeed ago
* add hint how to exclude the word `ago` for the uptime sensor

Localization should be handled separately, and globally for all places where `moment` is used.
In order to allow the user to profit from this further localization, `moment()` should be then be made available by `utils.js`.

closes #671