### PR TITLE
fix(CAMERA_STREAM): stream fails to resume after being suspended

### DIFF
--- a/scripts/directives/cameraStream.js
+++ b/scripts/directives/cameraStream.js
@@ -80,8 +80,6 @@ export default function (Api, $timeout) {
                hls.on(Hls.Events.MEDIA_ATTACHED, function () {
                   hls.loadSource(url);
                });
-               hls.on(Hls.Events.MEDIA_DETACHED, function () {
-               });
                hls.on(Hls.Events.MANIFEST_PARSED, function () {
                   Promise.resolve(el.play()).catch(() => {});
                });

--- a/scripts/directives/cameraStream.js
+++ b/scripts/directives/cameraStream.js
@@ -77,12 +77,12 @@ export default function (Api, $timeout) {
                   hls.destroy();
                }
                hls = new Hls(config);
-               hls.on(Hls.Events.MEDIA_ATTACHED, function (a, b) {
+               hls.on(Hls.Events.MEDIA_ATTACHED, function () {
                   hls.loadSource(url);
                });
-               hls.on(Hls.Events.MEDIA_DETACHED, function (a, b) {
+               hls.on(Hls.Events.MEDIA_DETACHED, function () {
                });
-               hls.on(Hls.Events.MANIFEST_PARSED, function (a, b) {
+               hls.on(Hls.Events.MANIFEST_PARSED, function () {
                   Promise.resolve(el.play()).catch(() => {});
                });
                hls.attachMedia(el);


### PR DESCRIPTION
Appears to be a regression in v1 of hls.js. An upstream issue created
at https://github.com/video-dev/hls.js/issues/3732

But I also found similar issue (https://github.com/video-dev/hls.js/issues/2473)
that seems to suggest that it's best to just re-initialize the Hls
instance instead of re-attaching the media so I'll just go with that
for now.

Fixes #688