### PR TITLE
refactor(CLIMATE): create separate directive

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -68,10 +68,14 @@ const config = {
          exclude: [
             'node_modules/**',
             'scripts/directives/*.html',
+            'scripts/tiles/*.html',
          ],
       }),
       html({
-         include: 'scripts/directives/*.html',
+         include: [
+            'scripts/directives/*.html',
+            'scripts/tiles/*.html',
+         ],
       }),
       styles({
          // Extract CSS into separate file (path specified through output.assetFileNames).

--- a/scripts/controllers/main.js
+++ b/scripts/controllers/main.js
@@ -1313,121 +1313,6 @@ App.controller('Main', function ($scope, $timeout, $location, Api, tmhDynamicLoc
       return false;
    };
 
-   $scope.climateTarget = function (item, entity) {
-      const value = entity.attributes.temperature || [
-         entity.attributes.target_temp_low,
-         entity.attributes.target_temp_high,
-      ].join(' - ');
-
-      if (item.filter) {
-         return item.filter(value);
-      }
-
-      return value;
-   };
-
-   $scope.reverseLookupClimateOption = function (item, entity, option) {
-      initializeClimateOptions(item, entity);
-      for (const [key, value] of Object.entries(item.climateOptions)) {
-         if (value === option) {
-            return key;
-         }
-      }
-      return option;
-   };
-
-   $scope.lookupClimateOption = function (item, entity, option) {
-      initializeClimateOptions(item, entity);
-      return item.climateOptions[option] || option;
-   };
-
-   function initializeClimateOptions (item, entity) {
-      if (typeof item.climateOptions === 'undefined') {
-         const options = item.useHvacMode ? entity.attributes.hvac_modes : entity.attributes.preset_modes;
-         const resolvedOption = {};
-         for (const option of options) {
-            if (item.states !== null && typeof item.states === 'object') {
-               resolvedOption[option] = item.states[option] || option;
-            } else {
-               resolvedOption[option] = option;
-            }
-         }
-         item.climateOptions = resolvedOption;
-      }
-   }
-
-   $scope.getClimateOptions = function (item, entity) {
-      initializeClimateOptions(item, entity);
-      return item.climateOptions;
-   };
-
-   $scope.getClimateCurrentOption = function (item, entity) {
-      const option = item.useHvacMode ? entity.state : entity.attributes.preset_mode;
-      return $scope.lookupClimateOption(item, entity, option);
-   };
-
-   $scope.setClimateOption = function ($event, item, entity, option) {
-      $event.preventDefault();
-      $event.stopPropagation();
-
-      let service;
-      const serviceData = {};
-      const resolvedOption = $scope.reverseLookupClimateOption(item, entity, option);
-
-      if (item.useHvacMode) {
-         service = 'set_hvac_mode';
-         serviceData.hvac_mode = resolvedOption;
-      } else {
-         service = 'set_preset_mode';
-         serviceData.preset_mode = resolvedOption;
-      }
-
-      callService(item, 'climate', service, serviceData);
-
-      $scope.closeActiveSelect();
-
-      return false;
-   };
-
-
-   $scope.increaseClimateTemp = function ($event, item, entity) {
-      $event.preventDefault();
-      $event.stopPropagation();
-
-      let value = parseFloat(entity.attributes.temperature);
-
-      value += (entity.attributes.target_temp_step || 1);
-
-      if (entity.attributes.max_temp) {
-         value = Math.min(value, entity.attributes.max_temp);
-      }
-
-      $scope.setClimateTemp(item, value);
-
-      return false;
-   };
-
-   $scope.decreaseClimateTemp = function ($event, item, entity) {
-      $event.preventDefault();
-      $event.stopPropagation();
-
-      let value = parseFloat(entity.attributes.temperature);
-
-      value -= (entity.attributes.target_temp_step || 1);
-
-      if (entity.attributes.min_temp) {
-         value = Math.max(value, entity.attributes.min_temp);
-      }
-
-      $scope.setClimateTemp(item, value);
-
-      return false;
-   };
-
-   $scope.setClimateTemp = function (item, value) {
-      callService(item, 'climate', 'set_temperature', { temperature: value });
-   };
-
    $scope.sendCover = function (service, item, entity) {
       callService(item, 'cover', service, {});
    };
@@ -2500,4 +2385,13 @@ App.controller('Main', function ($scope, $timeout, $location, Api, tmhDynamicLoc
          pingConnection();
       });
    }
+
+   // Temporary transitioning APIs to be able to access shared APIs from directives.
+
+   this.callService = callService;
+   this.closeActiveSelect = $scope.closeActiveSelect;
+   this.entityIcon = $scope.entityIcon;
+   this.itemSelectStyles = $scope.itemSelectStyles;
+   this.openSelect = $scope.openSelect;
+   this.selectOpened = $scope.selectOpened;
 });

--- a/scripts/directives.js
+++ b/scripts/directives.js
@@ -9,6 +9,8 @@ import ngMax from './directives/ngMax';
 import ngMin from './directives/ngMin';
 import onScroll from './directives/onScroll';
 import tile from './directives/tile';
+// Register tile directives.
+import './directives/tiles';
 
 App.directive('camera', camera);
 App.directive('cameraStream', cameraStream);

--- a/scripts/directives/tile.html
+++ b/scripts/directives/tile.html
@@ -518,49 +518,7 @@
       </div>
    </div>
 
-   <div ng-if="item.type === TYPES.CLIMATE" class="item-entity-container">
-      <div>
-         <div
-            class="item-button -center-right"
-            ng-if="entity.attributes.temperature && entity.state !== 'off'"
-            ng-click="increaseClimateTemp($event, item, entity)"
-         >
-            <i class="mdi mdi-plus"></i>
-         </div>
-         <div
-            class="item-button -bottom-right"
-            ng-if="entity.attributes.temperature && entity.state !== 'off'"
-            ng-click="decreaseClimateTemp($event, item, entity)"
-         >
-            <i class="mdi mdi-minus"></i>
-         </div>
-      </div>
-
-      <div class="item-climate">
-         <div class="item-climate--target">
-            <span ng-bind="climateTarget(item, entity)"></span>
-            <span ng-if="(_unit = entityUnit(item, entity))" class="item-climate--target--unit" ng-bind="_unit"></span>
-            <i class="item-climate--icon mdi" ng-class="entityIcon(item, entity)"></i>
-         </div>
-         <div
-            class="item-climate--mode"
-            ng-if="(_options = getClimateOptions(item, entity))"
-            ng-click="openSelect(item)"
-         >
-            <span ng-bind="getClimateCurrentOption(item, entity)"></span>
-         </div>
-      </div>
-      <div ng-if="selectOpened(item)" class="item-select" ng-style="itemSelectStyles(entity, Object.keys(_options))">
-         <div
-            class="item-select--option"
-            ng-repeat="option in _options track by $index"
-            ng-class="{'-active': option === lookupClimateOption(item, entity, entity.state)}"
-            ng-click="setClimateOption($event, item, entity, option)"
-         >
-            <span ng-bind="option"></span>
-         </div>
-      </div>
-   </div>
+   <div ng-if="item.type === TYPES.CLIMATE" class="item-entity-container" tile-climate item="item" entity="entity"></div>
 
    <div ng-if="item.type === TYPES.MEDIA_PLAYER" class="item-entity-container">
       <div class="media-player-table" ng-class="{'-has-state': _state, '-has-subtitle': _subtitle}">

--- a/scripts/directives/tile.js
+++ b/scripts/directives/tile.js
@@ -9,7 +9,7 @@ export default function () {
    return {
       restrict: 'AE',
       replace: false,
-      scope: true,
+      scope: false,
       template,
    };
 }

--- a/scripts/directives/tiles/index.js
+++ b/scripts/directives/tiles/index.js
@@ -1,0 +1,4 @@
+import { App } from '../../app';
+import tileClimate from './tileClimate';
+
+App.directive('tileClimate', tileClimate);

--- a/scripts/directives/tiles/tileClimate.html
+++ b/scripts/directives/tiles/tileClimate.html
@@ -1,0 +1,40 @@
+<div>
+   <div
+      class="item-button -center-right"
+      ng-if="ctrl.entity.attributes.temperature && ctrl.entity.state !== 'off'"
+      ng-click="ctrl.increaseClimateTemp($event)"
+   >
+      <i class="mdi mdi-plus"></i>
+   </div>
+   <div
+      class="item-button -bottom-right"
+      ng-if="ctrl.entity.attributes.temperature && ctrl.entity.state !== 'off'"
+      ng-click="ctrl.decreaseClimateTemp($event)"
+   >
+      <i class="mdi mdi-minus"></i>
+   </div>
+</div>
+<div class="item-climate">
+   <div class="item-climate--target">
+      <span>{{ ctrl.climateTarget() }}</span>
+      <span ng-if="(_unit = ctrl.rootCtrl.entityUnit(ctrl.item, ctrl.entity))" class="item-climate--target--unit">{{ _unit }}</span>
+      <i class="item-climate--icon mdi" ng-class="ctrl.rootCtrl.entityIcon(ctrl.item, ctrl.entity)"></i>
+   </div>
+   <div
+      class="item-climate--mode"
+      ng-if="(_options = ctrl.getClimateOptions())"
+      ng-click="ctrl.rootCtrl.openSelect(ctrl.item)"
+   >
+      <span>{{ ctrl.getClimateCurrentOption() }}</span>
+   </div>
+</div>
+<div ng-if="ctrl.rootCtrl.selectOpened(ctrl.item)" class="item-select" ng-style="ctrl.rootCtrl.itemSelectStyles(ctrl.entity, Object.keys(_options))">
+   <div
+      class="item-select--option"
+      ng-repeat="option in _options track by $index"
+      ng-class="{'-active': option === ctrl.lookupClimateOption(ctrl.entity.state)}"
+      ng-click="ctrl.setClimateOption($event, option)"
+   >
+      <span>{{ option }}</span>
+   </div>
+</div>

--- a/scripts/directives/tiles/tileClimate.js
+++ b/scripts/directives/tiles/tileClimate.js
@@ -1,0 +1,136 @@
+import template from './tileClimate.html';
+
+/**
+ * @ngInject
+ * @type {angular.IDirectiveFactory}
+ */
+export default function () {
+   return {
+      require: { rootCtrl: '^^ngController' },
+      restrict: 'AE',
+      template,
+      scope: {
+         item: '<',
+         entity: '<',
+      },
+      controllerAs: 'ctrl',
+      bindToController: true,
+      controller: ClimateController,
+   };
+}
+
+class ClimateController {
+   constructor () {
+      // Those are automatically injected after the controller is created.
+      this.entity = {};
+      this.item = {};
+      this.rootCtrl = null;
+   }
+
+   climateTarget () {
+      const { temperature, target_temp_low: tempLow, target_temp_high: tempHigh } = this.entity.attributes;
+      const value = temperature || [tempLow, tempHigh].join(' - ');
+      return this.item.filter ? this.item.filter(value) : value;
+   }
+
+   reverseLookupClimateOption (option) {
+      this.initializeClimateOptions();
+      for (const [key, value] of Object.entries(this.item.climateOptions)) {
+         if (value === option) {
+            return key;
+         }
+      }
+      return option;
+   }
+
+   lookupClimateOption (option) {
+      this.initializeClimateOptions();
+      return this.item.climateOptions[option] || option;
+   }
+
+   initializeClimateOptions () {
+      if (typeof this.item.climateOptions === 'undefined') {
+         const options = this.item.useHvacMode ? this.entity.attributes.hvac_modes : this.entity.attributes.preset_modes;
+         const resolvedOption = {};
+         for (const option of options) {
+            if (this.item.states !== null && typeof this.item.states === 'object') {
+               resolvedOption[option] = this.item.states[option] || option;
+            } else {
+               resolvedOption[option] = option;
+            }
+         }
+         this.item.climateOptions = resolvedOption;
+      }
+   }
+
+   getClimateOptions () {
+      this.initializeClimateOptions();
+      return this.item.climateOptions;
+   }
+
+   getClimateCurrentOption () {
+      const option = this.item.useHvacMode ? this.entity.state : this.entity.attributes.preset_mode;
+      return this.lookupClimateOption(option);
+   }
+
+   setClimateOption (event, option) {
+      event.preventDefault();
+      event.stopPropagation();
+
+      let service;
+      const serviceData = {};
+      const resolvedOption = this.reverseLookupClimateOption(option);
+
+      if (this.item.useHvacMode) {
+         service = 'set_hvac_mode';
+         serviceData.hvac_mode = resolvedOption;
+      } else {
+         service = 'set_preset_mode';
+         serviceData.preset_mode = resolvedOption;
+      }
+
+      this.rootCtrl.callService(this.item, 'climate', service, serviceData);
+      this.rootCtrl.closeActiveSelect();
+
+      return false;
+   }
+
+
+   increaseClimateTemp (event) {
+      event.preventDefault();
+      event.stopPropagation();
+
+      let value = parseFloat(this.entity.attributes.temperature);
+
+      value += (this.entity.attributes.target_temp_step || 1);
+
+      if (this.entity.attributes.max_temp) {
+         value = Math.min(value, this.entity.attributes.max_temp);
+      }
+
+      this.setClimateTemp(value);
+
+      return false;
+   }
+
+   decreaseClimateTemp (event) {
+      event.preventDefault();
+      event.stopPropagation();
+
+      let value = parseFloat(this.entity.attributes.temperature);
+
+      value -= (this.entity.attributes.target_temp_step || 1);
+
+      if (this.entity.attributes.min_temp) {
+         value = Math.max(value, this.entity.attributes.min_temp);
+      }
+
+      this.setClimateTemp(value);
+
+      return false;
+   }
+
+   setClimateTemp (value) {
+      this.rootCtrl.callService(this.item, 'climate', 'set_temperature', { temperature: value });
+   }
+}


### PR DESCRIPTION
Experimenting with separating each tile's code into its own directive.

To summarize, the specific tile's code is separate into its own directive and HTML template.

The directive's controller contains tile-specific code and is exposed as `ctrl` in the template.

Since `item` and `entity` are bound to the isolated scope of the directive, there is no need to pass those from the template anymore since the controller has access to them already. Only in case, we want to call the APIs from the main controller we need to pass them. That part is a bit unclean right now but could be made better eventually.

Please don't merge yet. Still figuring out if this is the best way to do it.

Please have a look and provide any feedback @alphasixtyfive @akloeckner 