### PR TITLE
fix(LIGHT): show brightness control only when on

### DIFF
--- a/scripts/directives/tile.html
+++ b/scripts/directives/tile.html
@@ -142,7 +142,7 @@
 
    <div ng-if="item.type === TYPES.LIGHT" class="item-entity-container">
       <div ng-if="!item.controlsEnabled">
-         <div ng-if="entity.state !== 'off'">
+         <div ng-if="entity.state === 'on'">
             <div
                ng-if="supportsFeature(FEATURES.LIGHT.BRIGHTNESS, entity)"
                class="item-button -center-right"


### PR DESCRIPTION
I noticed, my dimmable light shows the dim controls, even when it is `unavailable`.