### PR TITLE
fix(CLOCK): suppress undefined postfix

### DIFF
--- a/scripts/directives/clock.js
+++ b/scripts/directives/clock.js
@@ -8,10 +8,10 @@ export default function ($filter) {
    return {
       restrict: 'E',
       template: `
-         <div class="clock--h">{{ hour }}</div
+         <div class="clock--h"></div
          ><div class="clock--colon">:</div
-         ><div class="clock--m">{{ minute }}</div
-         ><div class="clock--postfix">{{ postfix }}</div>
+         ><div class="clock--m"></div
+         ><div class="clock--postfix"></div>
       `,
       link ($scope, $el, attrs) {
          const hourEl = $el[0].querySelector('.clock--h');
@@ -25,7 +25,7 @@ export default function ($filter) {
 
             hourEl.textContent = hour;
             minuteEl.textContent = minute;
-            postfixEl.textContent = postfix;
+            postfixEl.textContent = postfix || '';
          };
 
          updateTime();


### PR DESCRIPTION
On one of my devices, the undefined postfix from 24-h-format would be displayed as `undefined`.
This is the fix.

I also removed the templates from the HTML part, because they don't seem to used.