### PR TITLE
fix(HISTORY): fix tooltip time for some locales

### DIFF
--- a/scripts/globals/constants.js
+++ b/scripts/globals/constants.js
@@ -221,7 +221,7 @@ export const MINIMAL_CHART_OPTIONS = {
          display: true,
          ticks: {
             mirror: true,
-            callback: function (value, index, values) {
+            callback (value, index, values) {
                if (index === values.length - 1 || index === 0) {
                   return value;
                }
@@ -232,10 +232,11 @@ export const MINIMAL_CHART_OPTIONS = {
    },
    tooltips: {
       callbacks: {
-         title: function (tooltipItem, data) {
-            return timeAgo(data.datasets[tooltipItem[0].datasetIndex].data[tooltipItem[0].index].x);
+         title (tooltipItem, data) {
+            const { datasetIndex, index } = tooltipItem[0];
+            return timeAgo(data.datasets[datasetIndex].data[index].x);
          },
-         label: function (tooltipItem, data) {
+         label (tooltipItem, data) {
             return tooltipItem.value;
          },
       },

--- a/scripts/globals/constants.js
+++ b/scripts/globals/constants.js
@@ -233,7 +233,7 @@ export const MINIMAL_CHART_OPTIONS = {
    tooltips: {
       callbacks: {
          title: function (tooltipItem, data) {
-            return timeAgo(tooltipItem[0].label);
+            return timeAgo(data.datasets[tooltipItem[0].datasetIndex].data[tooltipItem[0].index].x);
          },
          label: function (tooltipItem, data) {
             return tooltipItem.value;


### PR DESCRIPTION
Apparently, the new localization features convert the `label` of the `tooltipItem` to something local.

This results in something like `Mai 23, 2021, 1:03:51`, for me in German. If we try to convert that using `timeAgo`, it fails.

The fix uses the raw `dataset[].data[].x`, which is `Sun May 23 2021 01:03:51 GMT+0200 (Mitteleuropäische Sommerzeit)` in my case. This value can be converted to a time ago properly.