### PR TITLE
fix(webmanifest): add start_url

### DIFF
--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,6 +1,6 @@
 {
   "name": "TileBoard",
-  "start_url": "index.html",
+  "start_url": "./index.html",
   "icons": [
     {
       "src": "favicon.svg",

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,5 +1,6 @@
 {
   "name": "TileBoard",
+  "start_url": "index.html",
   "icons": [
     {
       "src": "favicon.svg",


### PR DESCRIPTION
This is a requirement for installable web APKs. See #822 and criteria in https://github.com/resoai/TileBoard/issues/819#issuecomment-1059559336 .